### PR TITLE
Update Auctioneer registry and compute proxy address

### DIFF
--- a/contracts/api3-server-v1/AuctioneerRegistry.sol
+++ b/contracts/api3-server-v1/AuctioneerRegistry.sol
@@ -72,6 +72,7 @@ contract AuctioneerRegistry is Ownable, SelfMulticall {
     // The OEV proxy data is:
     //   - Chain ID
     //   - Data feed ID / dAPI name
+    //   - Is dAPI
     //   - Beneficiary address
     //   - Data
     // We do not derive/validate the proxy address on-chain in case the logic

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,8 +22,18 @@ function getDeploymentAddresses(chainId: ethers.BigNumberish) {
   return { api3ServerV1Address, proxyFactoryAddress };
 }
 
-function computeDapiProxyAddress(chainId: ethers.BigNumberish, dapiName: string, metadata: ethers.BytesLike) {
-  const { api3ServerV1Address, proxyFactoryAddress } = getDeploymentAddresses(chainId);
+interface ContractAddresses {
+  api3ServerV1Address: string;
+  proxyFactoryAddress: string;
+}
+
+function computeDapiProxyAddress(
+  chainId: ethers.BigNumberish,
+  dapiName: string,
+  metadata: ethers.BytesLike,
+  contracts: ContractAddresses = getDeploymentAddresses(chainId)
+) {
+  const { api3ServerV1Address, proxyFactoryAddress } = contracts;
   const dapiNameHash = ethers.solidityPackedKeccak256(['bytes32'], [ethers.encodeBytes32String(dapiName)]);
   const initcode = ethers.solidityPacked(
     ['bytes', 'bytes'],
@@ -39,9 +49,10 @@ function computeDapiProxyWithOevAddress(
   chainId: ethers.BigNumberish,
   dapiName: string,
   oevBeneficiary: ethers.AddressLike,
-  metadata: ethers.BytesLike
+  metadata: ethers.BytesLike,
+  contracts: ContractAddresses = getDeploymentAddresses(chainId)
 ) {
-  const { api3ServerV1Address, proxyFactoryAddress } = getDeploymentAddresses(chainId);
+  const { api3ServerV1Address, proxyFactoryAddress } = contracts;
   const dapiNameHash = ethers.solidityPackedKeccak256(['bytes32'], [ethers.encodeBytes32String(dapiName)]);
   const initcode = ethers.solidityPacked(
     ['bytes', 'bytes'],
@@ -59,9 +70,10 @@ function computeDapiProxyWithOevAddress(
 function computeDataFeedProxyAddress(
   chainId: ethers.BigNumberish,
   dataFeedId: ethers.BytesLike,
-  metadata: ethers.BytesLike
+  metadata: ethers.BytesLike,
+  contracts: ContractAddresses = getDeploymentAddresses(chainId)
 ) {
-  const { api3ServerV1Address, proxyFactoryAddress } = getDeploymentAddresses(chainId);
+  const { api3ServerV1Address, proxyFactoryAddress } = contracts;
   const initcode = ethers.solidityPacked(
     ['bytes', 'bytes'],
     [
@@ -76,9 +88,10 @@ function computeDataFeedProxyWithOevAddress(
   chainId: ethers.BigNumberish,
   dataFeedId: ethers.BytesLike,
   oevBeneficiary: ethers.AddressLike,
-  metadata: ethers.BytesLike
+  metadata: ethers.BytesLike,
+  contracts: ContractAddresses = getDeploymentAddresses(chainId)
 ) {
-  const { api3ServerV1Address, proxyFactoryAddress } = getDeploymentAddresses(chainId);
+  const { api3ServerV1Address, proxyFactoryAddress } = contracts;
   const initcode = ethers.solidityPacked(
     ['bytes', 'bytes'],
     [
@@ -93,6 +106,7 @@ function computeDataFeedProxyWithOevAddress(
 }
 
 export {
+  type ContractAddresses,
   computeDapiProxyAddress,
   computeDapiProxyWithOevAddress,
   computeDataFeedProxyAddress,


### PR DESCRIPTION
I've renamed the `metadata` to `data` to avoid confusion with proxy `metadata`. I used this naming convention in Auctioneer implementation as well. 

I also assume there is going to be a `bool` field specifying whether it's a dapi or dataFeed proxy. Maybe it could be `bytes32` in case we came up with more new proxies in the future. But it also seems unnecessary because the contract doesn't care about the schema and we can change it in case we need to.

Feel free to close, merge or edit. I can split it into multiple (more focused) PRs if you prefer.