### PR TITLE
Add cancelSubscriptions()

### DIFF
--- a/contracts/api3-server-v1/Api3Market.sol
+++ b/contracts/api3-server-v1/Api3Market.sol
@@ -234,6 +234,24 @@ contract Api3Market is HashRegistry, ExtendedSelfMulticall, IApi3Market {
         }
     }
 
+    /// @notice Called by the owner to cancel all subscriptions for a dAPI
+    /// that needs to be decommissioned urgently
+    /// @dev The root of a new dAPI pricing Merkle tree that excludes the dAPI
+    /// should be registered before canceling the subscriptions. Otherwise,
+    /// anyone can immediately buy the subscriptions again.
+    /// @param dapiName dAPI name
+    function cancelSubscriptions(bytes32 dapiName) external override onlyOwner {
+        require(
+            dapiNameToCurrentSubscriptionId[dapiName] != bytes32(0),
+            "Subscription queue empty"
+        );
+        dapiNameToCurrentSubscriptionId[dapiName] = bytes32(0);
+        AirseekerRegistry(airseekerRegistry).setDapiNameToBeDeactivated(
+            dapiName
+        );
+        emit CanceledSubscriptions(dapiName);
+    }
+
     /// @notice If the current subscription has ended, updates it with the one
     /// that will end next
     /// @dev The fact that there is a current subscription that has ended would

--- a/contracts/api3-server-v1/interfaces/IApi3Market.sol
+++ b/contracts/api3-server-v1/interfaces/IApi3Market.sol
@@ -16,6 +16,8 @@ interface IApi3Market is IHashRegistry, IExtendedSelfMulticall {
         uint256 paymentAmount
     );
 
+    event CanceledSubscriptions(bytes32 indexed dapiName);
+
     event UpdatedCurrentSubscriptionId(
         bytes32 indexed dapiName,
         bytes32 indexed subscriptionId
@@ -30,6 +32,8 @@ interface IApi3Market is IHashRegistry, IExtendedSelfMulticall {
         uint256 price,
         bytes calldata dapiManagementAndDapiPricingMerkleData
     ) external payable returns (bytes32 subscriptionId);
+
+    function cancelSubscriptions(bytes32 dapiName) external;
 
     function updateCurrentSubscriptionId(bytes32 dapiName) external;
 

--- a/docs/contracts/api3market.md
+++ b/docs/contracts/api3market.md
@@ -9,7 +9,7 @@ For example, buying a subscription for a [dAPI](./api3serverv1.md#dapi) that is 
 
 Api3Market inherits [HashRegistry](./hashregistry.md), which inherits Ownable, which means Api3Market has an owner.
 Unlike HashRegistry, the Api3Market ownership cannot be transferred or renounced (i.e., the owner specified at the deployment is immutable).
-Api3Market does not use the ownership functionality, which means that the owner is solely used for [HashRegistry functionality](./hashregistry.md#the-owner), which is setting signers for a hash type or setting a hash.
+In addition to [HashRegistry functionality](./hashregistry.md#the-owner), Api3Market allows its owner to cancel all subscriptions for a dAPI by calling `cancelSubscriptions()` in case the dAPI needs to be decomissioned urgently, without waiting for the ongoing subscriptions to end.
 
 ## Merkle roots as HashRegistry hash types
 


### PR DESCRIPTION
Say we have subscriptions S1->S2->S3 for a dAPI. Then we remove the dAPI from the dAPI pricing MMT and cancel the subscriptions by calling `cancelSubscriptions()`. Later on we add the same dAPI back to the dAPI pricing and a user buys S1. For a moment, I was suspicious that this would also revive the ...->S2->S3 part (which is not desirable), but after thinking a bit more I don't think that this would be the case. Let me know if you disagree.