### PR TITLE
Add repository url in package.json to resolve Release Notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "engines": {
     "node": "^20.12.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/api3dao/contracts.git"
+  },
   "private": false,
   "main": "dist/src/index",
   "types": "dist/src/index",


### PR DESCRIPTION
Mirrors: https://github.com/api3dao/chains/blob/3f96413f420a78b1579df8705fd837f3607764a2/package.json#L12-L14 (and others) to enable Renovate to resolve the package's GitHub Release Notes ([slack discussion](https://api3workspace.slack.com/archives/C027Y2FAV0S/p1712820209317779?thread_ts=1712565043.319269&cid=C027Y2FAV0S)).