### PR TITLE
Replaces ethers.toBeArray() with ethers.getBytes() to fix the random …

### DIFF
--- a/deploy/2_update_beacon_set.ts
+++ b/deploy/2_update_beacon_set.ts
@@ -39,7 +39,7 @@ module.exports = async () => {
               ind + 1,
               `0x${(ind + 1).toString().padStart(64, '0')}`,
               await deployer?.signMessage(
-                ethers.toBeArray(
+                ethers.getBytes(
                   ethers.solidityPackedKeccak256(
                     ['bytes32', 'uint256', 'bytes'],
                     [templateId, ind + 1, `0x${(ind + 1).toString().padStart(64, '0')}`]
@@ -72,7 +72,7 @@ module.exports = async () => {
             ind + 101,
             `0x${(ind + 101).toString().padStart(64, '0')}`,
             await deployer?.signMessage(
-              ethers.toBeArray(
+              ethers.getBytes(
                 ethers.solidityPackedKeccak256(
                   ['bytes32', 'uint256', 'bytes'],
                   [templateId, ind + 101, `0x${(ind + 101).toString().padStart(64, '0')}`]

--- a/test/access/HashRegistry.sol.ts
+++ b/test/access/HashRegistry.sol.ts
@@ -13,7 +13,7 @@ export async function signHash(
   let signatures: BytesLike[] = [];
   for (const signer of signers) {
     const signature = await signer.signMessage(
-      ethers.toBeArray(ethers.solidityPackedKeccak256(['bytes32', 'bytes32', 'uint256'], [hashType, hash, timestamp]))
+      ethers.getBytes(ethers.solidityPackedKeccak256(['bytes32', 'bytes32', 'uint256'], [hashType, hash, timestamp]))
     );
     signatures = [...signatures, signature];
   }
@@ -34,7 +34,7 @@ describe('HashRegistry', function () {
     let signatures: BytesLike[] = [];
     for (const [index, signer] of signers.entries()) {
       const signature = await signer.signMessage(
-        ethers.toBeArray(
+        ethers.getBytes(
           ethers.solidityPackedKeccak256(
             ['bytes32', 'address', 'uint256'],
             [SIGNATURE_DELEGATION_HASH_TYPE, delegates[index]!.address, endTimestamp]

--- a/test/api3-server-v1/Api3Market.sol.ts
+++ b/test/api3-server-v1/Api3Market.sol.ts
@@ -3821,7 +3821,7 @@ describe('Api3Market', function () {
                 timestampNow,
                 encodedValue,
                 await airnodes[i]!.signMessage(
-                  ethers.toBeArray(
+                  ethers.getBytes(
                     ethers.solidityPackedKeccak256(
                       ['bytes32', 'uint256', 'bytes'],
                       [templateIds[i], timestampNow, encodedValue]
@@ -3953,7 +3953,7 @@ describe('Api3Market', function () {
       const timestamp = await helpers.time.latest();
       const encodedValue = ethers.AbiCoder.defaultAbiCoder().encode(['int224'], [123]);
       const signature = await airnodes[0]!.signMessage(
-        ethers.toBeArray(
+        ethers.getBytes(
           ethers.solidityPackedKeccak256(['bytes32', 'uint256', 'bytes'], [templateIds[0], timestamp, encodedValue])
         )
       );

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -86,7 +86,7 @@ async function signData(
   data: BytesLike
 ) {
   const signature = await airnode.signMessage(
-    ethers.toBeArray(ethers.solidityPackedKeccak256(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data]))
+    ethers.getBytes(ethers.solidityPackedKeccak256(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, data]))
   );
   return signature;
 }
@@ -119,7 +119,7 @@ async function signOevData(
     ]
   );
   const signature = await airnode.signMessage(
-    ethers.toBeArray(ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [oevUpdateHash, templateId]))
+    ethers.getBytes(ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [oevUpdateHash, templateId]))
   );
   return signature;
 }
@@ -140,7 +140,7 @@ async function updateBeacon(
     timestamp,
     encodedValue,
     await airnode.signMessage(
-      ethers.toBeArray(
+      ethers.getBytes(
         ethers.solidityPackedKeccak256(['bytes32', 'uint256', 'bytes'], [templateId, timestamp, encodedValue])
       )
     )
@@ -175,7 +175,7 @@ async function updateBeaconSet(
       timestamp,
       encodedValue,
       await beaconUpdateDatum.airnode.signMessage(
-        ethers.toBeArray(
+        ethers.getBytes(
           ethers.solidityPackedKeccak256(
             ['bytes32', 'uint256', 'bytes'],
             [beaconUpdateDatum.templateId, timestamp, encodedValue]


### PR DESCRIPTION
…Signature mismatch revert message in tests

Closes https://github.com/api3dao/contracts/issues/39

This was a nasty bug. The issue is basically using ethers.toBeArray() instead of ethers.getBytes() on a hex that starts with 0.  When this happens, toBeArray() drops the leading zeros so the signature will be different and the contract will revert when verifying them.

Here's a script to prove the fix works (needs to be run with hardhat):

```
import { ethers } from 'hardhat';

function main() {
    const hex =
        "0x005d11a5a4b257a8152ce171762c07a1279999dba84e2e55bf3aca46257eb0ee";

    const getBytes = ethers.getBytes(hex);
    console.log("🚀 ~ main ~ getBytes:", getBytes)

    const toBeArray = ethers.toBeArray(hex);
    console.log("🚀 ~ main ~ toBeArray:", toBeArray)

    // toBeArray internally calls this function
    // it basically takes the hex string and casts it to a bigint
    const toBigInt = ethers.toBigInt(hex);
    console.log("🚀 ~ main ~ toBigInt:", toBigInt)

    // then it converts it to back to a hex string
    const toString = toBigInt.toString(16)
    console.log("🚀 ~ main ~ toString:", toString)
    
    console.log("🚀 ~ main ~ original hex:", hex)
}

main();
```