### PR TITLE
Validate that the gas estimation Beacon set has been initialized

### DIFF
--- a/scripts/validate-deployments.ts
+++ b/scripts/validate-deployments.ts
@@ -11,7 +11,7 @@ import {
   chainsSupportedByOevAuctions,
 } from '../data/chain-support.json';
 import managerMultisigAddresses from '../data/manager-multisig.json';
-import type { AccessControlRegistry, OwnableCallForwarder } from '../src/index';
+import type { AccessControlRegistry, Api3ServerV1, OwnableCallForwarder } from '../src/index';
 
 async function validateDeployments(network: string) {
   if (Object.keys(managerMultisigAddresses).includes(network)) {
@@ -46,32 +46,82 @@ async function validateDeployments(network: string) {
         `${network} OwnableCallForwarder owner ${goFetchOwnableCallForwarderOwner.data.toLowerCase()} is not the same as the manager multisig address ${managerMultisigAddresses[network as keyof typeof managerMultisigAddresses].toLowerCase()}`
       );
     }
-    if (chainsSupportedByMarket.includes(network)) {
-      // Validate that ExternalMulticallSimulator and Api3Market are dAPI name setters
-      const rootRole = ethers.solidityPackedKeccak256(['address'], [ownableCallForwarderAddress]);
-      const adminRole = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32'],
-        [rootRole, ethers.solidityPackedKeccak256(['string'], ['Api3ServerV1 admin'])]
+    if (chainsSupportedByDapis.includes(network)) {
+      // Validate that the Beacon set used to estimate gas is initialized
+      const { address: api3ServerV1Address, abi: api3ServerV1Abi } = JSON.parse(
+        fs.readFileSync(join('deployments', network, `Api3ServerV1.json`), 'utf8')
       );
-      const dapiNameSetterRole = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32'],
-        [adminRole, ethers.solidityPackedKeccak256(['string'], ['dAPI name setter'])]
-      );
-      const { address: accessControlRegistryAddress, abi: accessControlRegistryAbi } = JSON.parse(
-        fs.readFileSync(join('deployments', network, `AccessControlRegistry.json`), 'utf8')
-      );
-      const accessControlRegistry = new ethers.Contract(
-        accessControlRegistryAddress,
-        accessControlRegistryAbi,
+      const api3ServerV1 = new ethers.Contract(
+        api3ServerV1Address,
+        api3ServerV1Abi,
         provider
-      ) as unknown as AccessControlRegistry;
-      const isTestnet = CHAINS.find((chain) => chain.alias === network)?.testnet;
-      if (!isTestnet) {
-        const { address: externalMulticallSimulatorAddress } = JSON.parse(
-          fs.readFileSync(join('deployments', network, `ExternalMulticallSimulator.json`), 'utf8')
+      ) as unknown as Api3ServerV1;
+      const gasEstimationBeaconSetId = '0xfee26235840c5bb25159e649ff825d97f1446de6042291b57755bb94f6e19e97';
+      const goFetchGasEstimationBeaconSet = await go(async () => api3ServerV1.dataFeeds(gasEstimationBeaconSetId), {
+        retries: 5,
+        attemptTimeoutMs: 10_000,
+        totalTimeoutMs: 50_000,
+        delay: {
+          type: 'random',
+          minDelayMs: 2000,
+          maxDelayMs: 5000,
+        },
+      });
+      if (!goFetchGasEstimationBeaconSet.success || !goFetchGasEstimationBeaconSet.data) {
+        throw new Error(`${network} gas estimation Beacon set could not be fetched`);
+      }
+      if (goFetchGasEstimationBeaconSet.data[0] !== 4n || goFetchGasEstimationBeaconSet.data[1] !== 4n) {
+        throw new Error(`${network} gas estimation Beacon set is not initialized as expected`);
+      }
+      if (chainsSupportedByMarket.includes(network)) {
+        // Validate that ExternalMulticallSimulator and Api3Market are dAPI name setters
+        const rootRole = ethers.solidityPackedKeccak256(['address'], [ownableCallForwarderAddress]);
+        const adminRole = ethers.solidityPackedKeccak256(
+          ['bytes32', 'bytes32'],
+          [rootRole, ethers.solidityPackedKeccak256(['string'], ['Api3ServerV1 admin'])]
         );
-        const goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus = await go(
-          async () => accessControlRegistry.hasRole(dapiNameSetterRole, externalMulticallSimulatorAddress),
+        const dapiNameSetterRole = ethers.solidityPackedKeccak256(
+          ['bytes32', 'bytes32'],
+          [adminRole, ethers.solidityPackedKeccak256(['string'], ['dAPI name setter'])]
+        );
+        const { address: accessControlRegistryAddress, abi: accessControlRegistryAbi } = JSON.parse(
+          fs.readFileSync(join('deployments', network, `AccessControlRegistry.json`), 'utf8')
+        );
+        const accessControlRegistry = new ethers.Contract(
+          accessControlRegistryAddress,
+          accessControlRegistryAbi,
+          provider
+        ) as unknown as AccessControlRegistry;
+        const isTestnet = CHAINS.find((chain) => chain.alias === network)?.testnet;
+        if (!isTestnet) {
+          const { address: externalMulticallSimulatorAddress } = JSON.parse(
+            fs.readFileSync(join('deployments', network, `ExternalMulticallSimulator.json`), 'utf8')
+          );
+          const goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus = await go(
+            async () => accessControlRegistry.hasRole(dapiNameSetterRole, externalMulticallSimulatorAddress),
+            {
+              retries: 5,
+              attemptTimeoutMs: 10_000,
+              totalTimeoutMs: 50_000,
+              delay: {
+                type: 'random',
+                minDelayMs: 2000,
+                maxDelayMs: 5000,
+              },
+            }
+          );
+          if (!goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus.success) {
+            throw new Error(`${network} ExternalMulticallSimulator dAPI name setter role status could not be fetched`);
+          }
+          if (!goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus.data) {
+            throw new Error(`${network} ExternalMulticallSimulator does not have the dAPI name setter role`);
+          }
+        }
+        const { address: api3MarketAddress } = JSON.parse(
+          fs.readFileSync(join('deployments', network, `Api3Market.json`), 'utf8')
+        );
+        const goFetchApi3MarketDapiNameSetterRoleStatus = await go(
+          async () => accessControlRegistry.hasRole(dapiNameSetterRole, api3MarketAddress),
           {
             retries: 5,
             attemptTimeoutMs: 10_000,
@@ -83,34 +133,12 @@ async function validateDeployments(network: string) {
             },
           }
         );
-        if (!goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus.success) {
-          throw new Error(`${network} ExternalMulticallSimulator dAPI name setter role status could not be fetched`);
+        if (!goFetchApi3MarketDapiNameSetterRoleStatus.success) {
+          throw new Error(`${network} Api3Market dAPI name setter role status could not be fetched`);
         }
-        if (!goFetchExternalMulticallSimulatorDapiNameSetterRoleStatus.data) {
-          throw new Error(`${network} ExternalMulticallSimulator does not have the dAPI name setter role`);
+        if (!goFetchApi3MarketDapiNameSetterRoleStatus.data) {
+          throw new Error(`${network} Api3Market does not have the dAPI name setter role`);
         }
-      }
-      const { address: api3MarketAddress } = JSON.parse(
-        fs.readFileSync(join('deployments', network, `Api3Market.json`), 'utf8')
-      );
-      const goFetchApi3MarketDapiNameSetterRoleStatus = await go(
-        async () => accessControlRegistry.hasRole(dapiNameSetterRole, api3MarketAddress),
-        {
-          retries: 5,
-          attemptTimeoutMs: 10_000,
-          totalTimeoutMs: 50_000,
-          delay: {
-            type: 'random',
-            minDelayMs: 2000,
-            maxDelayMs: 5000,
-          },
-        }
-      );
-      if (!goFetchApi3MarketDapiNameSetterRoleStatus.success) {
-        throw new Error(`${network} Api3Market dAPI name setter role status could not be fetched`);
-      }
-      if (!goFetchApi3MarketDapiNameSetterRoleStatus.data) {
-        throw new Error(`${network} Api3Market does not have the dAPI name setter role`);
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/73

Currently succeeds except for neon-evm-testnet. @hiletmis should it not also fail for avalanche-testnet due to https://github.com/api3dao/logdata-miner/issues/236? I expected the Beacon set to read `(101, 101)` but it reads `(4, 4)` like in other chains.