### PR TITLE
Extract go parameters in provider calls in scripts

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -1,0 +1,12 @@
+import type { GoAsyncOptions } from '@api3/promise-utils';
+
+export const goAsyncOptions: GoAsyncOptions = {
+  retries: 5,
+  attemptTimeoutMs: 10_000,
+  totalTimeoutMs: 50_000,
+  delay: {
+    type: 'random',
+    minDelayMs: 2000,
+    maxDelayMs: 5000,
+  },
+};

--- a/scripts/validate-deployments.ts
+++ b/scripts/validate-deployments.ts
@@ -22,6 +22,8 @@ import type {
   OwnableCallForwarder,
 } from '../src/index';
 
+import { goAsyncOptions } from './constants';
+
 async function validateDeployments(network: string) {
   if (chainsSupportedByManagerMultisig.includes(network)) {
     const provider = new ethers.JsonRpcProvider((config.networks[network] as any).url);
@@ -35,16 +37,10 @@ async function validateDeployments(network: string) {
       gnosisSafeWithoutProxyAbi,
       provider
     ) as unknown as GnosisSafeWithoutProxy;
-    const goFetchGnosisSafeWithoutProxyOwners = await go(async () => gnosisSafeWithoutProxy.getOwners(), {
-      retries: 5,
-      attemptTimeoutMs: 10_000,
-      totalTimeoutMs: 50_000,
-      delay: {
-        type: 'random',
-        minDelayMs: 2000,
-        maxDelayMs: 5000,
-      },
-    });
+    const goFetchGnosisSafeWithoutProxyOwners = await go(
+      async () => gnosisSafeWithoutProxy.getOwners(),
+      goAsyncOptions
+    );
     if (!goFetchGnosisSafeWithoutProxyOwners.success || !goFetchGnosisSafeWithoutProxyOwners.data) {
       throw new Error(`${network} GnosisSafeWithoutProxy owners could not be fetched`);
     }
@@ -65,16 +61,10 @@ async function validateDeployments(network: string) {
       );
     }
 
-    const goFetchGnosisSafeWithoutProxyThreshold = await go(async () => gnosisSafeWithoutProxy.getThreshold(), {
-      retries: 5,
-      attemptTimeoutMs: 10_000,
-      totalTimeoutMs: 50_000,
-      delay: {
-        type: 'random',
-        minDelayMs: 2000,
-        maxDelayMs: 5000,
-      },
-    });
+    const goFetchGnosisSafeWithoutProxyThreshold = await go(
+      async () => gnosisSafeWithoutProxy.getThreshold(),
+      goAsyncOptions
+    );
     if (!goFetchGnosisSafeWithoutProxyThreshold.success || !goFetchGnosisSafeWithoutProxyThreshold.data) {
       throw new Error(`${network} GnosisSafeWithoutProxy threshold could not be fetched`);
     }
@@ -93,16 +83,7 @@ async function validateDeployments(network: string) {
       ownableCallForwarderAbi,
       provider
     ) as unknown as OwnableCallForwarder;
-    const goFetchOwnableCallForwarderOwner = await go(async () => ownableCallForwarder.owner(), {
-      retries: 5,
-      attemptTimeoutMs: 10_000,
-      totalTimeoutMs: 50_000,
-      delay: {
-        type: 'random',
-        minDelayMs: 2000,
-        maxDelayMs: 5000,
-      },
-    });
+    const goFetchOwnableCallForwarderOwner = await go(async () => ownableCallForwarder.owner(), goAsyncOptions);
     if (!goFetchOwnableCallForwarderOwner.success || !goFetchOwnableCallForwarderOwner.data) {
       throw new Error(`${network} OwnableCallForwarder owner could not be fetched`);
     }
@@ -121,16 +102,10 @@ async function validateDeployments(network: string) {
         api3ReaderProxyV1FactoryAbi,
         provider
       ) as unknown as Api3ReaderProxyV1Factory;
-      const goFetchApi3ReaderProxyV1FactoryOwner = await go(async () => api3ReaderProxyV1Factory.owner(), {
-        retries: 5,
-        attemptTimeoutMs: 10_000,
-        totalTimeoutMs: 50_000,
-        delay: {
-          type: 'random',
-          minDelayMs: 2000,
-          maxDelayMs: 5000,
-        },
-      });
+      const goFetchApi3ReaderProxyV1FactoryOwner = await go(
+        async () => api3ReaderProxyV1Factory.owner(),
+        goAsyncOptions
+      );
       if (!goFetchApi3ReaderProxyV1FactoryOwner.success || !goFetchApi3ReaderProxyV1FactoryOwner.data) {
         throw new Error(`${network} Api3ReaderProxyV1Factory owner could not be fetched`);
       }
@@ -152,16 +127,10 @@ async function validateDeployments(network: string) {
           api3MarketV2Abi,
           provider
         ) as unknown as Api3MarketV2;
-        const goFetchApi3MarketV2AirseekerRegistry = await go(async () => api3MarketV2.airseekerRegistry(), {
-          retries: 5,
-          attemptTimeoutMs: 10_000,
-          totalTimeoutMs: 50_000,
-          delay: {
-            type: 'random',
-            minDelayMs: 2000,
-            maxDelayMs: 5000,
-          },
-        });
+        const goFetchApi3MarketV2AirseekerRegistry = await go(
+          async () => api3MarketV2.airseekerRegistry(),
+          goAsyncOptions
+        );
         if (!goFetchApi3MarketV2AirseekerRegistry.success || !goFetchApi3MarketV2AirseekerRegistry.data) {
           throw new Error(`${network} Api3MarketV2 AirseekerRegistry address could not be fetched`);
         }
@@ -182,16 +151,7 @@ async function validateDeployments(network: string) {
             api3MarketV2.hashTypeToSignersHash(
               ethers.solidityPackedKeccak256(['string'], ['dAPI management Merkle root'])
             ),
-          {
-            retries: 5,
-            attemptTimeoutMs: 10_000,
-            totalTimeoutMs: 50_000,
-            delay: {
-              type: 'random',
-              minDelayMs: 2000,
-              maxDelayMs: 5000,
-            },
-          }
+          goAsyncOptions
         );
         if (
           !goFetchApi3MarketV2DapiManagementMerkleRootSignersHash.success ||
@@ -213,16 +173,7 @@ async function validateDeployments(network: string) {
             api3MarketV2.hashTypeToSignersHash(
               ethers.solidityPackedKeccak256(['string'], ['dAPI pricing Merkle root'])
             ),
-          {
-            retries: 5,
-            attemptTimeoutMs: 10_000,
-            totalTimeoutMs: 50_000,
-            delay: {
-              type: 'random',
-              minDelayMs: 2000,
-              maxDelayMs: 5000,
-            },
-          }
+          goAsyncOptions
         );
         if (
           !goFetchApi3MarketV2DapiPricingMerkleRootSignersHash.success ||
@@ -260,16 +211,7 @@ async function validateDeployments(network: string) {
         ) as unknown as AccessControlRegistry;
         const goFetchApi3MarketV2DapiNameSetterRoleStatus = await go(
           async () => accessControlRegistry.hasRole(dapiNameSetterRole, api3MarketV2Address),
-          {
-            retries: 5,
-            attemptTimeoutMs: 10_000,
-            totalTimeoutMs: 50_000,
-            delay: {
-              type: 'random',
-              minDelayMs: 2000,
-              maxDelayMs: 5000,
-            },
-          }
+          goAsyncOptions
         );
         if (!goFetchApi3MarketV2DapiNameSetterRoleStatus.success) {
           throw new Error(`${network} Api3MarketV2 dAPI name setter role status could not be fetched`);
@@ -298,16 +240,7 @@ async function validateDeployments(network: string) {
                 ])
               )
             ),
-          {
-            retries: 5,
-            attemptTimeoutMs: 10_000,
-            totalTimeoutMs: 50_000,
-            delay: {
-              type: 'random',
-              minDelayMs: 2000,
-              maxDelayMs: 5000,
-            },
-          }
+          goAsyncOptions
         );
         if (!goFetchApi3ServerV1OevExtensionAuctioneerRoleStatus.success) {
           throw new Error(`${network} Api3ServerV1OevExtension auctioneer role status could not be fetched`);
@@ -354,16 +287,7 @@ async function validateDeployments(network: string) {
                   ])
               )
             ),
-          {
-            retries: 5,
-            attemptTimeoutMs: 10_000,
-            totalTimeoutMs: 50_000,
-            delay: {
-              type: 'random',
-              minDelayMs: 2000,
-              maxDelayMs: 5000,
-            },
-          }
+          goAsyncOptions
         );
         if (!goFetchApi3ServerV1OevExtensionAuctioneerRoleStatus.success) {
           throw new Error(`${network} Api3ServerV1OevExtension auctioneer role status could not be fetched`);

--- a/scripts/verify-deployments.ts
+++ b/scripts/verify-deployments.ts
@@ -18,6 +18,8 @@ import {
   chainsSupportedByOevAuctions,
 } from '../data/chain-support.json';
 
+import { goAsyncOptions } from './constants';
+
 const METADATA_HASH_LENGTH = 85 * 2;
 // https://github.com/Arachnid/deterministic-deployment-proxy/tree/be3c5974db5028d502537209329ff2e730ed336c#proxy-address
 const CREATE2_FACTORY_ADDRESS = '0x4e59b44847b379578588920cA78FbF26c0B4956C';
@@ -53,16 +55,7 @@ async function verifyDeployments(network: string) {
     );
 
     if (deployment.address === expectedDeterministicDeploymentAddress) {
-      const goFetchContractCode = await go(async () => provider.getCode(deployment.address), {
-        retries: 5,
-        attemptTimeoutMs: 10_000,
-        totalTimeoutMs: 50_000,
-        delay: {
-          type: 'random',
-          minDelayMs: 2000,
-          maxDelayMs: 5000,
-        },
-      });
+      const goFetchContractCode = await go(async () => provider.getCode(deployment.address), goAsyncOptions);
       if (!goFetchContractCode.success || !goFetchContractCode.data) {
         throw new Error(`${network} ${contractName} (deterministic) contract code could not be fetched`);
       }
@@ -70,16 +63,10 @@ async function verifyDeployments(network: string) {
         throw new Error(`${network} ${contractName} (deterministic) contract code does not exist`);
       }
     } else {
-      const goFetchCreationTx = await go(async () => provider.getTransaction(deployment.transactionHash), {
-        retries: 5,
-        attemptTimeoutMs: 10_000,
-        totalTimeoutMs: 50_000,
-        delay: {
-          type: 'random',
-          minDelayMs: 2000,
-          maxDelayMs: 5000,
-        },
-      });
+      const goFetchCreationTx = await go(
+        async () => provider.getTransaction(deployment.transactionHash),
+        goAsyncOptions
+      );
       if (!goFetchCreationTx.success || !goFetchCreationTx.data) {
         throw new Error(`${network} ${contractName} creation tx could not be fetched`);
       }


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/239

I figured this kind of a minimal touch is ideal. The call-specific error messages help with debugging RPC issues (such as https://github.com/api3dao/contracts/issues/223) so I didn't want to generalize things and lose such context.