### PR TITLE
Set `packageManager for corepack users

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -86,5 +86,6 @@
   },
   "dependencies": {
     "ethers": "^6.13.2"
-  }
+  },
+  "packageManager": "pnpm@9.12.2"
 }


### PR DESCRIPTION
Related to https://github.com/api3dao/tasks/issues/1338

* This PR adds `packageManager` field to `package.json`
* Removes pnpm version definition from CIs as they are redundant with current settings