### PR TITLE
Validate OEV Network proxies

### DIFF
--- a/scripts/validate-deployments.ts
+++ b/scripts/validate-deployments.ts
@@ -54,7 +54,7 @@ async function validateDeployments(network: string) {
       throw new Error(`${network} GnosisSafeWithoutProxy owners could not be fetched`);
     }
     const { owners: managerMultisigOwners, threshold: managerMultisigThreshold } =
-      managerMultisigMetadata[CHAINS.find((chain: any) => chain.alias === network)?.testnet ? 'testnet' : 'mainnet'];
+      managerMultisigMetadata[CHAINS.find((chain) => chain.alias === network)?.testnet ? 'testnet' : 'mainnet'];
     if (
       !(
         managerMultisigOwners.length === goFetchGnosisSafeWithoutProxyOwners.data.length &&
@@ -328,7 +328,7 @@ async function validateDeployments(network: string) {
         if (!goFetchCollateralRateProxyAddress.success) {
           throw new Error('OevAuctionHouse collateral rate proxy address could not be fetched');
         }
-        const oevAuctionChainId = CHAINS.find((chain: any) => chain.alias === network)!.id;
+        const oevAuctionChainId = CHAINS.find((chain) => chain.alias === network)!.id;
         const ethUsdRateReaderProxyV1Address = computeApi3ReaderProxyV1Address(
           oevAuctionChainId,
           'ETH/USD',
@@ -343,7 +343,7 @@ async function validateDeployments(network: string) {
 
         // Validate that native currency rate proxies are set
         const chainsWithNativeRateProxies = chainsSupportedByMarket.reduce((acc, chainAlias) => {
-          const chain = CHAINS.find((chain: any) => chain.alias === chainAlias)!;
+          const chain = CHAINS.find((chain) => chain.alias === chainAlias)!;
           if (!chain.testnet) {
             acc.push(chain);
           }
@@ -449,7 +449,7 @@ async function main() {
       try {
         await validateDeployments(network);
       } catch (error) {
-        if (CHAINS.find((chain: any) => chain.alias === network)?.testnet) {
+        if (CHAINS.find((chain) => chain.alias === network)?.testnet) {
           erroredTestnets.push(network);
         } else {
           erroredMainnets.push(network);

--- a/scripts/validate-deployments.ts
+++ b/scripts/validate-deployments.ts
@@ -316,7 +316,7 @@ async function main() {
       try {
         await validateDeployments(network);
       } catch (error) {
-        if (CHAINS.find((chain) => chain.alias === network)?.testnet) {
+        if (CHAINS.find((chain: any) => chain.alias === network)?.testnet) {
           erroredTestnets.push(network);
         } else {
           erroredMainnets.push(network);

--- a/scripts/verify-deployments.ts
+++ b/scripts/verify-deployments.ts
@@ -203,7 +203,7 @@ async function main() {
       try {
         await verifyDeployments(network);
       } catch (error) {
-        if (CHAINS.find((chain: any) => chain.alias === network)?.testnet) {
+        if (CHAINS.find((chain) => chain.alias === network)?.testnet) {
           erroredTestnets.push(network);
         } else {
           erroredMainnets.push(network);

--- a/scripts/verify-deployments.ts
+++ b/scripts/verify-deployments.ts
@@ -203,7 +203,7 @@ async function main() {
       try {
         await verifyDeployments(network);
       } catch (error) {
-        if (CHAINS.find((chain) => chain.alias === network)?.testnet) {
+        if (CHAINS.find((chain: any) => chain.alias === network)?.testnet) {
           erroredTestnets.push(network);
         } else {
           erroredMainnets.push(network);


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/241

This revealed the following issues

```
OevAuctionHouse collateral rate proxy address is 0xa47Fd122b11CdD7aad7c3e8B740FB91D83Ce43D1 while it should have been 0x5b0cf2b36a65a6BB085D501B971e4c102B9Cd473

OevAuctionHouse native currency rate proxy of conflux with address 0x968eA23acAD164AdaEcb86Cab6C3DEa4BC9d52D6 could not be read from
OevAuctionHouse native currency rate proxy of hashkey with address 0x183ec28c374CE8D0b44477FbED37328F5f950324 could not be read from
OevAuctionHouse native currency rate proxy of lukso with address 0x5741Da3db211e137b72505B7AD05E8455309D67a could not be read from
OevAuctionHouse native currency rate proxy of sonic with address 0x726D2E87d73567ecA1b75C063Bd09c1493655918 could not be read from
```

The first error is tracked here https://github.com/api3dao/manager-multisig/issues/514

Out of the following four, lukso and sonic appear on the Market, while conflux and hashkey doesn't yet.