### PR TITLE
Add survey-roles script and use it to survey existing integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prettier:check": "prettier --check \"./**/*.{js,ts,md,json,sol}\"",
     "prettier": "prettier --write \"./**/*.{js,ts,md,json,sol}\"",
     "postpack": "./postpack.sh",
+    "survey-roles": "hardhat run scripts/survey-roles.ts",
     "test": "hardhat test --parallel",
     "test:coverage": "hardhat coverage",
     "test:extended": "EXTENDED_TEST=TRUE hardhat test --parallel",

--- a/scripts/survey-roles.ts
+++ b/scripts/survey-roles.ts
@@ -1,0 +1,123 @@
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+
+import { CHAINS } from '@api3/chains';
+import { go } from '@api3/promise-utils';
+import { config, ethers } from 'hardhat';
+
+import { chainsSupportedByManagerMultisig, chainsSupportedByDapis } from '../data/chain-support.json';
+
+import { goAsyncOptions } from './constants';
+
+// This may need to be tuned for different RPCs
+const MAXIMUM_GETLOGS_BLOCK_RANGE = 50_000;
+
+async function surveyRoles(network: string) {
+  if (!chainsSupportedByDapis.includes(network)) {
+    return;
+  }
+  // The provider must serve all logs for this script to work. The default
+  // chain RPC URLs don't necessarily support that. In such cases, you can
+  // override the default RPC URL through .env. See
+  // https://github.com/api3dao/chains/tree/main?tab=readme-ov-file#hardhatconfignetworks
+  const provider = new ethers.JsonRpcProvider((config.networks[network] as any).url);
+  const { address: accessControlRegistryAddress, abi: accessControlRegistryAbi } = JSON.parse(
+    fs.readFileSync(join('deployments', network, `AccessControlRegistry.json`), 'utf8')
+  );
+  const accessControlRegistryInterface = new ethers.Interface(accessControlRegistryAbi);
+  const blockNumber = await provider.getBlockNumber();
+  let logs: any[] = [];
+  let percentage = 0;
+  for (let fromBlockNumber = 0; fromBlockNumber <= blockNumber; fromBlockNumber += MAXIMUM_GETLOGS_BLOCK_RANGE) {
+    const goGetLogs = await go(
+      async () =>
+        provider.getLogs({
+          address: accessControlRegistryAddress,
+          fromBlock: fromBlockNumber,
+          toBlock:
+            fromBlockNumber + MAXIMUM_GETLOGS_BLOCK_RANGE > blockNumber
+              ? blockNumber
+              : fromBlockNumber + MAXIMUM_GETLOGS_BLOCK_RANGE,
+        }),
+      goAsyncOptions
+    );
+    if (!goGetLogs.success || !goGetLogs.data) {
+      throw new Error(`${network} AccessControlRegistry logs could not be fetched`);
+    }
+    logs = [...logs, ...goGetLogs.data];
+    if (percentage !== Math.floor((fromBlockNumber * 100) / blockNumber)) {
+      percentage = Math.floor((fromBlockNumber * 100) / blockNumber);
+      // eslint-disable-next-line no-console
+      console.log(`${percentage}%`);
+    }
+  }
+  const parsedLogs = logs.map((log) => accessControlRegistryInterface.parseLog(log));
+  const roleToGrantees: Record<string, Set<string>> = {};
+  for (const parsedLog of parsedLogs) {
+    if (parsedLog!.name === 'RoleGranted') {
+      if (roleToGrantees[parsedLog!.args[0]]) {
+        roleToGrantees[parsedLog!.args[0]]!.add(parsedLog!.args[1]);
+      } else {
+        roleToGrantees[parsedLog!.args[0]] = new Set([parsedLog!.args[1]]);
+      }
+    } else if (parsedLog!.name === 'RoleRevoked') {
+      roleToGrantees[parsedLog!.args[0]]!.delete(parsedLog!.args[1]);
+    }
+  }
+  for (const [role, grantees] of Object.entries(roleToGrantees)) {
+    if (parsedLogs.some((parsedLog) => parsedLog!.name === 'InitializedManager' && parsedLog!.args[0] === role)) {
+      // Manager roles can't dangle so we don't worry about them
+      continue;
+    }
+    const roleInitializationParsedLog = parsedLogs.find(
+      (parsedLog) => parsedLog!.name === 'InitializedRole' && parsedLog!.args[0] === role
+    );
+    // eslint-disable-next-line no-console
+    console.log(`${roleInitializationParsedLog!.args[2]}: ${[...grantees].join(' ')}`);
+    // The important roles and expected grantees are:
+    // - Api3ServerV1: "dAPI name setter" (OwnableCallForwarder and Api3MarketV2)
+    // - Api3ServerV1OevExtension: "Withdrawer" (none), "Auctioneer" (OwnableCallForwarder and auctioneer EOA)
+    // - OevAuctionHouse: "Proxy setter" (none), "Withdrawer" (none), "Auctioneer" (OwnableCallForwarder and auctioneer EOA)
+    // In addition, all admin roles should only be granted to OwnableCallForwarder
+  }
+}
+
+async function main() {
+  const networks = process.env.NETWORK ? [process.env.NETWORK] : chainsSupportedByManagerMultisig;
+
+  const erroredMainnets: string[] = [];
+  const erroredTestnets: string[] = [];
+  await Promise.all(
+    networks.map(async (network) => {
+      try {
+        await surveyRoles(network);
+      } catch (error) {
+        if (CHAINS.find((chain) => chain.alias === network)?.testnet) {
+          erroredTestnets.push(network);
+        } else {
+          erroredMainnets.push(network);
+        }
+        // eslint-disable-next-line no-console
+        console.error(error, '\n');
+      }
+    })
+  );
+  if (erroredTestnets.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(`Survey failed on testnets: ${erroredTestnets.join(', ')}`);
+  }
+  if (erroredMainnets.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(`Survey failed on: ${erroredMainnets.join(', ')}`);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+}
+
+/* eslint-disable */
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.log(error);
+    process.exit(1);
+  });

--- a/scripts/survey-roles.ts
+++ b/scripts/survey-roles.ts
@@ -1,3 +1,7 @@
+// This script will not work with all providers but there are workarounds.
+// See https://github.com/api3dao/contracts/pull/310
+// TODO: Only display select role trees (which was not necessary at the time
+// this script was implemented)
 import * as fs from 'node:fs';
 import { join } from 'node:path';
 
@@ -9,17 +13,12 @@ import { chainsSupportedByManagerMultisig, chainsSupportedByDapis } from '../dat
 
 import { goAsyncOptions } from './constants';
 
-// This may need to be tuned for different RPCs
-const MAXIMUM_GETLOGS_BLOCK_RANGE = 50_000;
+const MAXIMUM_GETLOGS_BLOCK_RANGE = 1_000;
 
 async function surveyRoles(network: string) {
   if (!chainsSupportedByDapis.includes(network)) {
     return;
   }
-  // The provider must serve all logs for this script to work. The default
-  // chain RPC URLs don't necessarily support that. In such cases, you can
-  // override the default RPC URL through .env. See
-  // https://github.com/api3dao/chains/tree/main?tab=readme-ov-file#hardhatconfignetworks
   const provider = new ethers.JsonRpcProvider((config.networks[network] as any).url);
   const { address: accessControlRegistryAddress, abi: accessControlRegistryAbi } = JSON.parse(
     fs.readFileSync(join('deployments', network, `AccessControlRegistry.json`), 'utf8')


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/293

- [x] apechain
- [x] arbitrum
- [x] astar
- [x] avalanche (1)
- [x] base (1)
- [x] bitlayer
- [x] blast (1)
- [x] bob
- [x] bsc (1)
- [x] conflux
- [x] core
- [x] ethereum
- [x] fantom
- [x] fraxtal
- [x] gnosis
- [x] hashkey
- [x] ink
- [x] inevm
- [ ] kava (6)
- [x] kroma
- [x] lightlink (5)
- [x] linea
- [x] lukso
- [x] lumia (3)
- [x] manta
- [x] mantle (1)
- [x] merlin (3)
- [x] metal
- [x] metis
- [x] mode
- [x] moonbeam (4)
- [x] moonriver (4)
- [x] oev-network
- [x] opbnb (1)
- [x] optimism (1)
- [x] polygon (1)
- [x] polygon-zkevm
- [x] rari
- [x] scroll
- [x] sei (5)
- [x] sonic
- [x] taiko (3)
- [x] world
- [x] x-layer
- [x] zircuit

(1) Overrode default RPC URL with Alchemy
(2) Overrode default RPC URL with dRPC
(3) Used a `MAXIMUM_GETLOGS_BLOCK_RANGE` of `1000`
(4) Overrode default RPC URL with dRPC and used a `MAXIMUM_GETLOGS_BLOCK_RANGE` of `10000`
(5) Checked manually over the blockchain explorer
(6) Used a `MAXIMUM_GETLOGS_BLOCK_RANGE` of `1000`, [started from block number `7622817`](https://kavascan.com/tx/0xd8f2b36105b5a23feb6a8c4c8168f7f025cd8646c4b41b9d8c23f52c2aed9bc4) and added a delay in the loop to avoid getting 420 errors