### PR TITLE
Stricter CLI command

### DIFF
--- a/.changeset/heavy-lobsters-attend.md
+++ b/.changeset/heavy-lobsters-attend.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': patch
+---
+
+Have the print-api3readerproxyv1-address CLI command print better looking errors

--- a/.changeset/tame-avocados-heal.md
+++ b/.changeset/tame-avocados-heal.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': patch
+---
+
+Have the print-api3readerproxyv1-address CLI command require strict validation by default

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ yargs(hideBin(process.argv))
           ethers.keccak256(ethers.encodeBytes32String(args['dapi-name']))
         );
         if (timestamp! + BigInt(24 * 60 * 60) < Date.now() / 1000) {
-          const message = '⚠️ Feed timestamp appears to be stale';
+          const message = `⚠️ Feed timestamp (${new Date(Number(timestamp) * 1000).toISOString()}) appears to be older than a day`;
           // eslint-disable-next-line no-console
           console.warn(message);
         }
@@ -79,7 +79,7 @@ yargs(hideBin(process.argv))
       try {
         const code = await provider.getCode(proxyAddress);
         if (code === '0x') {
-          const message = '⚠️ Proxy appears to not have been deployed';
+          const message = `⚠️ Proxy at ${proxyAddress} appears to not have been deployed`;
           // eslint-disable-next-line no-console
           console.warn(message);
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { CHAINS } from '@api3/chains';
 import * as ethers from 'ethers';
 import yargs from 'yargs';
@@ -51,9 +52,9 @@ yargs(hideBin(process.argv))
     async (args) => {
       const chain = CHAINS.find((chain) => chain.id === args['chain-id']);
       if (!chain) {
-        throw new Error(`Chain with ID ${args['chain-id']} is not known`);
+        console.error(`Chain with ID ${args['chain-id']} is not known`);
+        process.exit(1);
       }
-      // eslint-disable-next-line no-console
       console.log(`dApp alias: ${args['dapp-alias']}\nchain: ${chain.name}\ndAPI name: ${args['dapi-name']}`);
       const provider = new ethers.JsonRpcProvider(
         chain.providers.find((provider) => provider.alias === 'default')!.rpcUrl
@@ -71,17 +72,17 @@ yargs(hideBin(process.argv))
       } catch (error) {
         const message = '⚠️ Attempted to read the feed and failed';
         if (strict) {
-          throw new Error(`${message}\n${error}`);
+          console.error(`${message}\n${error}`);
+          process.exit(1);
         }
-        // eslint-disable-next-line no-console
         console.warn(message);
       }
       if (timestamp && timestamp + BigInt(24 * 60 * 60) < Date.now() / 1000) {
         const message = `⚠️ Feed timestamp (${new Date(Number(timestamp) * 1000).toISOString()}) appears to be older than a day`;
         if (strict) {
-          throw new Error(message);
+          console.error(message);
+          process.exit(1);
         }
-        // eslint-disable-next-line no-console
         console.warn(message);
       }
       const proxyAddress = computeDappSpecificApi3ReaderProxyV1Address(
@@ -95,23 +96,21 @@ yargs(hideBin(process.argv))
       } catch (error) {
         const message = '⚠️ Attempted to check if the proxy has been deployed and failed';
         if (strict) {
-          throw new Error(`${message}\n${error}`);
+          console.error(`${message}\n${error}`);
+          process.exit(1);
         }
-        // eslint-disable-next-line no-console
         console.warn(message);
       }
       if (code && code === '0x') {
         const message = `⚠️ Proxy at ${proxyAddress} appears to not have been deployed`;
         if (strict) {
-          throw new Error(message);
+          console.error(message);
+          process.exit(1);
         }
-        // eslint-disable-next-line no-console
         console.warn(message);
       }
       const marketUrl = `https://market.api3.org/${chain.alias}/${slugify(args['dapi-name'])}`;
-      // eslint-disable-next-line no-console
       console.log(`• Please confirm that ${marketUrl} points to an active feed.`);
-      // eslint-disable-next-line no-console
       console.log(
         `• Your proxy address is ${chain.explorer.browserUrl}address/${proxyAddress}\nPlease confirm that there is a contract deployed at this address before using it.`
       );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ yargs(hideBin(process.argv))
         );
       } catch (error) {
         const message = '⚠️ Attempted to read the feed and failed';
-        if (strict) {
+        if (args['strict']) {
           console.error(message);
           console.error((error as Error).message);
           process.exit(1);
@@ -80,7 +80,7 @@ yargs(hideBin(process.argv))
       }
       if (timestamp && timestamp + BigInt(24 * 60 * 60) < Date.now() / 1000) {
         const message = `⚠️ Feed timestamp (${new Date(Number(timestamp) * 1000).toISOString()}) appears to be older than a day`;
-        if (strict) {
+        if (args['strict']) {
           console.error(message);
           process.exit(1);
         }
@@ -96,7 +96,7 @@ yargs(hideBin(process.argv))
         code = await provider.getCode(proxyAddress);
       } catch (error) {
         const message = '⚠️ Attempted to check if the proxy has been deployed and failed';
-        if (strict) {
+        if (args['strict']) {
           console.error(message);
           console.error((error as Error).message);
           process.exit(1);
@@ -105,7 +105,7 @@ yargs(hideBin(process.argv))
       }
       if (code && code === '0x') {
         const message = '⚠️ Proxy does not appear to have been deployed';
-        if (strict) {
+        if (args['strict']) {
           console.error(message);
           process.exit(1);
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,8 @@ yargs(hideBin(process.argv))
       } catch (error) {
         const message = '⚠️ Attempted to read the feed and failed';
         if (strict) {
-          console.error(`${message}\n${error}`);
+          console.error(message);
+          console.error((error as Error).message);
           process.exit(1);
         }
         console.warn(message);
@@ -96,7 +97,8 @@ yargs(hideBin(process.argv))
       } catch (error) {
         const message = '⚠️ Attempted to check if the proxy has been deployed and failed';
         if (strict) {
-          console.error(`${message}\n${error}`);
+          console.error(message);
+          console.error((error as Error).message);
           process.exit(1);
         }
         console.warn(message);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,12 +62,14 @@ yargs(hideBin(process.argv))
           ethers.keccak256(ethers.encodeBytes32String(args['dapi-name']))
         );
         if (timestamp! + BigInt(24 * 60 * 60) < Date.now() / 1000) {
+          const message = '⚠️ Feed timestamp appears to be stale';
           // eslint-disable-next-line no-console
-          console.warn('⚠️ Feed timestamp appears to be stale');
+          console.warn(message);
         }
       } catch {
+        const message = '⚠️ Attempted to read the feed and failed';
         // eslint-disable-next-line no-console
-        console.warn('⚠️ Attempted to read the feed and failed');
+        console.warn(message);
       }
       const proxyAddress = computeDappSpecificApi3ReaderProxyV1Address(
         args['dapp-alias'],
@@ -77,12 +79,14 @@ yargs(hideBin(process.argv))
       try {
         const code = await provider.getCode(proxyAddress);
         if (code === '0x') {
+          const message = '⚠️ Proxy appears to not have been deployed';
           // eslint-disable-next-line no-console
-          console.warn('⚠️ Proxy appears to not have been deployed');
+          console.warn(message);
         }
       } catch {
+        const message = '⚠️ Attempted to check if the proxy has been deployed and failed';
         // eslint-disable-next-line no-console
-        console.warn('⚠️ Attempted to check if the proxy has been deployed and failed');
+        console.warn(message);
       }
       const marketUrl = `https://market.api3.org/${chain.alias}/${slugify(args['dapi-name'])}`;
       // eslint-disable-next-line no-console

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,7 +104,7 @@ yargs(hideBin(process.argv))
         console.warn(message);
       }
       if (code && code === '0x') {
-        const message = `⚠️ Proxy at ${proxyAddress} appears to not have been deployed`;
+        const message = '⚠️ Proxy does not appear to have been deployed';
         if (strict) {
           console.error(message);
           process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,7 +114,7 @@ yargs(hideBin(process.argv))
       const marketUrl = `https://market.api3.org/${chain.alias}/${slugify(args['dapi-name'])}`;
       console.log(`• Please confirm that ${marketUrl} points to an active feed.`);
       console.log(
-        `• Your proxy address is ${chain.explorer.browserUrl}address/${proxyAddress}\nPlease confirm that there is a contract deployed at this address before using it.`
+        `• Your proxy is at ${chain.explorer.browserUrl}address/${proxyAddress}\nPlease confirm that there is a contract deployed at this address before using it.`
       );
     }
   )


### PR DESCRIPTION
The main change is
```
npx @api3/contracts print-api3readerproxyv1-address --dapp-alias lendle --chain-id 59144 --dapi-name WBTC/USD
```
now prints the below (and does not print the proxy address)
```
dApp alias: lendle
chain: Linea
dAPI name: WBTC/USD
⚠️ Proxy does not appear to have been deployed
```

To get the same behavior as before, you need to add a `--strict false` argument  as in
```
npx @api3/contracts print-api3readerproxyv1-address --dapp-alias lendle --chain-id 59144 --dapi-name WBTC/USD --strict false
```
which prints
```
dApp alias: lendle
chain: Linea
dAPI name: WBTC/USD
⚠️ Proxy does not appear to have been deployed
• Please confirm that https://market.api3.org/linea/wbtc-usd points to an active feed.
• Your proxy is at https://lineascan.build/address/0x32a5f22F630FAdcbD5C81E4cCfe6Bac98DC3c227
Please confirm that there is a contract deployed at this address before using it.
```