### PR TITLE
Hardcode `OwnableCallForwarder` initial owner

### DIFF
--- a/deploy/1_deploy.ts
+++ b/deploy/1_deploy.ts
@@ -11,6 +11,7 @@ import { CHAINS } from '../src/index';
 import type { Api3ReaderProxyV1Factory, OwnableCallForwarder } from '../src/index';
 
 const MAXIMUM_SUBSCRIPTION_QUEUE_LENGTH = 10;
+const EXPECTED_DEPLOYER_ADDRESS = ethers.getAddress('0x07b589f06bD0A5324c4E2376d66d2F4F25921DE1');
 
 module.exports = async () => {
   const { deploy, log } = deployments;
@@ -35,7 +36,7 @@ module.exports = async () => {
         log(`Deploying OwnableCallForwarder`);
         return deploy('OwnableCallForwarder', {
           from: deployer!.address,
-          args: [deployer!.address],
+          args: [EXPECTED_DEPLOYER_ADDRESS],
           log: true,
           deterministicDeployment: process.env.DETERMINISTIC ? ethers.ZeroHash : '',
         });


### PR DESCRIPTION
* For deterministic deployment addresses, `OwnableCallForwarder` must be initialized with a predefined owner. 
* The owner is defined as `EXPECTED_DEPLOYER_ADDRESS`.
