### PR TITLE
Improve check-chains and check-dapps checking logic

### DIFF
--- a/scripts/check-chains.ts
+++ b/scripts/check-chains.ts
@@ -34,20 +34,22 @@ const chainsMap = new Map(CHAINS.map((chain) => [chain.alias, chain]));
 const jsonChainsMap = new Map(jsonChains.map((chain) => [chain.alias, chain]));
 
 // Validation: Ensure that each JSON file is represented in the CHAINS array
+const chainAliases = new Set(chainsMap.keys());
+const jsonAliases = new Set(jsonChainsMap.keys());
 if (CHAINS.length !== jsonChains.length) {
-  const chainAliases = new Set(chainsMap.keys());
-  const jsonAliases = new Set(jsonChainsMap.keys());
-
-  const missingInChains = [...jsonAliases].filter((alias) => !chainAliases.has(alias));
-  const missingInJson = [...chainAliases].filter((alias) => !jsonAliases.has(alias));
-
   logs.push(
     'Generated chains differs in length to the number of JSON files',
-    `Generated CHAINS length = ${CHAINS.length}. Expected ${jsonChains.length} chains`,
-    missingInChains.length > 0 ? `Missing in CHAINS: ${missingInChains.join(', ')}` : '',
-    missingInJson.length > 0 ? `Missing in JSON files: ${missingInJson.join(', ')}` : '',
-    '\n'
+    `Generated CHAINS length = ${CHAINS.length}. Expected ${jsonChains.length} chains\n`
   );
+}
+
+const missingInChains = [...jsonAliases].filter((alias) => !chainAliases.has(alias));
+if (missingInChains.length > 0) {
+  logs.push(`Missing in CHAINS: ${missingInChains.join(', ')}\n`);
+}
+const missingInJson = [...chainAliases].filter((alias) => !jsonAliases.has(alias));
+if (missingInJson.length > 0) {
+  logs.push(`Missing in JSON files: ${missingInJson.join(', ')}\n`);
 }
 
 jsonChains.forEach((chain: Chain) => {

--- a/scripts/check-dapps.ts
+++ b/scripts/check-dapps.ts
@@ -36,20 +36,22 @@ const dappsMap = new Map(DAPPS.map((dapp) => [Object.keys(dapp.aliases)[0], dapp
 const jsonDappsMap = new Map(jsonDapps.map((dapp) => [Object.keys(dapp.aliases)[0], dapp]));
 
 // Validation: Ensure that each JSON file is represented in the DAPPS array
+const dappNames = new Set(dappsMap.keys());
+const jsonNames = new Set(jsonDappsMap.keys());
 if (DAPPS.length !== jsonDapps.length) {
-  const dappNames = new Set(dappsMap.keys());
-  const jsonNames = new Set(jsonDappsMap.keys());
-
-  const missingInDapps = [...jsonNames].filter((name) => !dappNames.has(name));
-  const missingInJson = [...dappNames].filter((name) => !jsonNames.has(name));
-
   logs.push(
     'Generated dapps differs in length to the number of JSON files',
-    `Generated DAPPS length = ${DAPPS.length}. Expected ${jsonDapps.length} dApps`,
-    missingInDapps.length > 0 ? `Missing in DAPPS: ${missingInDapps.join(', ')}` : '',
-    missingInJson.length > 0 ? `Missing in JSON files: ${missingInJson.join(', ')}` : '',
-    '\n'
+    `Generated DAPPS length = ${DAPPS.length}. Expected ${jsonDapps.length} dApps\n`
   );
+}
+
+const missingInDapps = [...jsonNames].filter((name) => !dappNames.has(name));
+if (missingInDapps.length > 0) {
+  logs.push(`Missing in DAPPS: ${missingInDapps.join(', ')}\n`);
+}
+const missingInJson = [...dappNames].filter((name) => !jsonNames.has(name));
+if (missingInJson.length > 0) {
+  logs.push(`Missing in JSON files: ${missingInJson.join(', ')}\n`);
 }
 
 jsonDapps.forEach((dapp: Dapp) => {

--- a/scripts/check-dapps.ts
+++ b/scripts/check-dapps.ts
@@ -11,25 +11,14 @@ const INPUT_DIR = path.join('data', 'dapps');
 const fileNames = fs.readdirSync(INPUT_DIR);
 const jsonFiles = fileNames.filter((fileName) => fileName.endsWith('.json'));
 
+const logs: string[] = [];
+
 const jsonDapps: Dapp[] = jsonFiles.map((filePath: string) => {
   const fullPath = path.join(INPUT_DIR, filePath);
   const fileContentRaw = fs.readFileSync(fullPath, 'utf8');
-  return JSON.parse(fileContentRaw);
-});
+  const dapp: Dapp = JSON.parse(fileContentRaw);
 
-const logs: string[] = [];
-
-// Validation: Ensure that each JSON file is represented in the DAPPS array
-if (DAPPS.length !== jsonDapps.length) {
-  logs.push(
-    'Generated dapps differs in length to the number of JSON files',
-    `Generated DAPPS length = ${DAPPS.length}. Expected ${jsonDapps.length} dApps\n`
-  );
-}
-
-// Validation: Ensure that each JSON file is named as a prefix of one of the dApp's titles
-jsonFiles.forEach((filePath: string, index: number) => {
-  const dapp: Dapp = jsonDapps[index]!;
+  // Validation: Ensure that each JSON file is named as a prefix of one of the dApp's titles
   const uniqueDappTitles = [
     ...new Set(Object.values(dapp.aliases).map((dappAliasValue) => toLowerKebabCase(dappAliasValue.title))),
   ];
@@ -39,22 +28,45 @@ jsonFiles.forEach((filePath: string, index: number) => {
       `Current value: ${filePath}. Expected to be prefix of: ${uniqueDappTitles.join('/')}\n`
     );
   }
+  return dapp;
 });
 
-jsonDapps.forEach((dapp: Dapp, index: number) => {
+// Lookup by alias
+const dappsMap = new Map(DAPPS.map((dapp) => [Object.keys(dapp.aliases)[0], dapp]));
+const jsonDappsMap = new Map(jsonDapps.map((dapp) => [Object.keys(dapp.aliases)[0], dapp]));
+
+// Validation: Ensure that each JSON file is represented in the DAPPS array
+if (DAPPS.length !== jsonDapps.length) {
+  const dappNames = new Set(dappsMap.keys());
+  const jsonNames = new Set(jsonDappsMap.keys());
+
+  const missingInDapps = [...jsonNames].filter((name) => !dappNames.has(name));
+  const missingInJson = [...dappNames].filter((name) => !jsonNames.has(name));
+
+  logs.push(
+    'Generated dapps differs in length to the number of JSON files',
+    `Generated DAPPS length = ${DAPPS.length}. Expected ${jsonDapps.length} dApps`,
+    missingInDapps.length > 0 ? `Missing in DAPPS: ${missingInDapps.join(', ')}` : '',
+    missingInJson.length > 0 ? `Missing in JSON files: ${missingInJson.join(', ')}` : '',
+    '\n'
+  );
+}
+
+jsonDapps.forEach((dapp: Dapp) => {
+  const dappName = Object.keys(dapp.aliases)[0];
+
   const res = dappSchema.safeParse(dapp);
   // Validation: Ensure each JSON file content conforms to the required schema
   if (!res.success) {
     const errors = res.error.issues.map((issue) => {
       return `  path: '${issue.path.join('.')}' => '${issue.message}' `;
     });
-    logs.push(`dApp '${Object.keys(dapp.aliases)}' contains the following errors:\n${errors.join('\n')}\n`);
+    logs.push(`dApp '${dappName}' contains the following errors:\n${errors.join('\n')}\n`);
   }
 
-  // Validation: Ensure that the latest JSON content is represented in each Dapp object
-  const existingDapp = DAPPS[index];
-  if (!deepEqual(dapp, existingDapp)) {
-    logs.push(`dApp '${Object.keys(dapp.aliases)}' differs to the currently generated Dapp object in DAPPS\n`);
+  const existingDapp = dappsMap.get(dappName);
+  if (existingDapp && !deepEqual(dapp, existingDapp)) {
+    logs.push(`dApp '${dappName}' differs to the currently generated Dapp object in DAPPS\n`);
   }
 });
 


### PR DESCRIPTION
Closes #460. Same logic applied to both files: use a map to validate by name rather than by list index therefore avoiding false errors when a chain or dapp is missing. It will now also print the name of the missing. I've also refactored the name validation to occur earlier when the files are initially read rather than in an extra `forEach` (the diff makes this a bit hard to see).