### PR TITLE
Update Markdown link checking workflow

### DIFF
--- a/.github/workflows/check-md-links.yml
+++ b/.github/workflows/check-md-links.yml
@@ -1,6 +1,6 @@
 name: Check Markdown links
 
-on: push
+on: pull_request
 
 jobs:
   check-md-links:
@@ -9,4 +9,6 @@ jobs:
     - name: Clone @api3/contracts
       uses: actions/checkout@v4
     - name: Check Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@v1
+      with:
+        check-modified-files-only: 'yes'


### PR DESCRIPTION
Old repo recommends migration: https://github.com/gaurav-nelson/github-action-markdown-link-check?tab=readme-ov-file#-%EF%B8%8F-deprecation-notice-apr-2025-

We're getting a lot of 429s recently, this may be a solution