### PR TITLE
Tako tako isolated market

### DIFF
--- a/.changeset/strong-apes-enjoy.md
+++ b/.changeset/strong-apes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': minor
+---
+
+Add TakoTako weETH/ETH isolated market to dApp details

--- a/data/dapps/takotako.json
+++ b/data/dapps/takotako.json
@@ -1,6 +1,10 @@
 {
   "aliases": {
-    "takotako": { "chains": ["taiko"], "title": "TakoTako" },
+    "takotako": {
+      "chains": ["taiko"],
+      "title": "TakoTako",
+      "description": "Only to be used for the main markets."
+    },
     "takotako-weeth-eth": {
       "chains": ["taiko"],
       "title": "TakoTako weETH/ETH isolated market",

--- a/data/dapps/takotako.json
+++ b/data/dapps/takotako.json
@@ -1,6 +1,11 @@
 {
   "aliases": {
-    "takotako": { "chains": ["taiko"], "title": "TakoTako" }
+    "takotako": { "chains": ["taiko"], "title": "TakoTako" },
+    "takotako-weeth-eth": {
+      "chains": ["taiko"],
+      "title": "TakoTako weETH/ETH isolated market",
+      "description": "Only to be used for the weETH/ETH isolated market."
+    }
   },
   "homepageUrl": "https://www.takotako.xyz/"
 }

--- a/src/generated/dapps.ts
+++ b/src/generated/dapps.ts
@@ -68,7 +68,17 @@ export const DAPPS: Dapp[] = [
   { aliases: { stability: { chains: ['sonic'], title: 'Stability' } }, homepageUrl: 'https://stability.farm/' },
   { aliases: { stout: { chains: ['sonic'], title: 'Stout' } }, homepageUrl: 'https://stout.fi/' },
   { aliases: { takara: { chains: ['sei'], title: 'Takara Lend' } }, homepageUrl: 'https://takaralend.com/' },
-  { aliases: { takotako: { chains: ['taiko'], title: 'TakoTako' } }, homepageUrl: 'https://www.takotako.xyz/' },
+  {
+    aliases: {
+      takotako: { chains: ['taiko'], title: 'TakoTako' },
+      'takotako-weeth-eth': {
+        chains: ['taiko'],
+        title: 'TakoTako weETH/ETH isolated market',
+        description: 'Only to be used for the weETH/ETH isolated market.',
+      },
+    },
+    homepageUrl: 'https://www.takotako.xyz/',
+  },
   { aliases: { tunnl: { chains: ['polygon'], title: 'tunnl' } }, homepageUrl: 'https://www.tunnl.exchange/' },
   {
     aliases: { 'vicuna-finance': { chains: ['sonic'], title: 'Vicuna Finance' } },

--- a/src/generated/dapps.ts
+++ b/src/generated/dapps.ts
@@ -70,7 +70,7 @@ export const DAPPS: Dapp[] = [
   { aliases: { takara: { chains: ['sei'], title: 'Takara Lend' } }, homepageUrl: 'https://takaralend.com/' },
   {
     aliases: {
-      takotako: { chains: ['taiko'], title: 'TakoTako' },
+      takotako: { chains: ['taiko'], title: 'TakoTako', description: 'Only to be used for the main markets.' },
       'takotako-weeth-eth': {
         chains: ['taiko'],
         title: 'TakoTako weETH/ETH isolated market',


### PR DESCRIPTION
[TakoTako](https://www.takotako.xyz/) apart from it's main markets, supports also isolated ones. Currently, there is only one -> [weETH/ETH](https://www.takotako.xyz/marketdetail?type=isolate&marketId=0xe882a56b8c0c1a5561febf846614b88718dc5d9e), but it should have a separate dApp alias, because it's a completely separate contract (likely with separate searcher bots).