### PR TITLE
Add a workflow to check for changesets on pull requests

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -1,0 +1,31 @@
+name: Check for Changeset
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  require-changeset:
+    runs-on: ubuntu-latest
+    if: github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
+    steps:
+      - name: Clone @api3/contracts
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check for changeset
+        run: pnpm changeset status --since=origin/main


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/463

This PR introduces a new workflow to verify the existence of a changeset file in pull requests.
If no changeset is required, an empty changeset file must still be included. 

Implementation adapted from an old [workflow](https://github.com/api3dao/chains/blob/89deb44d84a95014895fe20d00bf833a525eb1a0/.github/workflows/continuous-build.yml#L54).