### PR TITLE
Add workflow to initiate package release

### DIFF
--- a/.github/workflows/initiate-package-release.yml
+++ b/.github/workflows/initiate-package-release.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
-      packages: write
       pull-requests: write
 
     steps:
@@ -20,21 +18,6 @@ jobs:
           BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
           if [[ "$BRANCH_NAME" != "main" ]]; then
             echo "Branch $BRANCH_NAME is not allowed to use this action"
-            exit 1
-          fi
-
-      - name: Check if runner is a CODEOWNER
-        run: |
-          CODEOWNERS=$(grep -v '^#' .github/CODEOWNERS | awk '{for(i=2;i<=NF;++i)print $i}' | sort | uniq)
-          IS_OWNER=false
-          for OWNER in $CODEOWNERS; do
-            if [[ "${{ github.actor }}" == "$OWNER" ]]; then
-              IS_OWNER=true
-              break
-            fi
-          done
-          if [[ "$IS_OWNER" != "true" ]]; then
-            echo "User ${{ github.actor }} is not a CODEOWNER. Exiting."
             exit 1
           fi
 

--- a/.github/workflows/initiate-package-release.yml
+++ b/.github/workflows/initiate-package-release.yml
@@ -1,0 +1,57 @@
+# https://github.com/changesets/action
+name: Initiate-Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  initiate-release:
+    name: Initiate-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Check if main branch is used
+        run: |
+          BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+          if [[ "$BRANCH_NAME" != "main" ]]; then
+            echo "Branch $BRANCH_NAME is not allowed to use this action"
+            exit 1
+          fi
+
+      - name: Check if runner is a CODEOWNER
+        run: |
+          CODEOWNERS=$(grep -v '^#' .github/CODEOWNERS | awk '{for(i=2;i<=NF;++i)print $i}' | sort | uniq)
+          IS_OWNER=false
+          for OWNER in $CODEOWNERS; do
+            if [[ "${{ github.actor }}" == "$OWNER" ]]; then
+              IS_OWNER=true
+              break
+            fi
+          done
+          if [[ "$IS_OWNER" != "true" ]]; then
+            echo "User ${{ github.actor }} is not a CODEOWNER. Exiting."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check changeset files
+        id: check_files
+        run: |
+          if find ./.changeset -maxdepth 1 -type f -name "*.md" ! -name "README.md" | grep -q .; then
+            echo "files_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "files_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create release PR
+        if: ${{ steps.check_files.outputs.files_exists == 'true' }}
+        run: gh pr create -B production -H main --title 'Initiate release' --body 'Merges main into production' --reviewer bbenligiray
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #524 

This PR introduces a new workflow that creates a release initiation PR (aka `Initiate release`) 

Workflow checks if it is running on `main` branch and triggered by a `CODEOWNER`

Due to GitHub PR rules an `Auto-Release` workflow cannot be utilized on contracts repo unlike data-feeds [implementation](https://github.com/api3dao/data-feeds/blob/main/.github/workflows/auto-release-packages.yml)

 