### PR TITLE
Fix WBTC title and description in Morpho dApp alias

### DIFF
--- a/.changeset/stale-candies-arrive.md
+++ b/.changeset/stale-candies-arrive.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': patch
+---
+
+Fix typo from WTBC to WBTC

--- a/data/dapps/morpho.json
+++ b/data/dapps/morpho.json
@@ -12,8 +12,8 @@
     },
     "morpho-wbtc-usdc-860-lltv": {
       "chains": ["ethereum"],
-      "title": "Morpho WTBC/USDC 86% LLTV",
-      "description": "Only to be used for the WTBC/USDC 86% LLTV market."
+      "title": "Morpho WBTC/USDC 86% LLTV",
+      "description": "Only to be used for the WBTC/USDC 86% LLTV market."
     },
     "morpho-cbbtc-usdc-860-lltv": {
       "chains": ["ethereum"],

--- a/src/generated/dapps.ts
+++ b/src/generated/dapps.ts
@@ -41,8 +41,8 @@ export const DAPPS: Dapp[] = [
       },
       'morpho-wbtc-usdc-860-lltv': {
         chains: ['ethereum'],
-        title: 'Morpho WTBC/USDC 86% LLTV',
-        description: 'Only to be used for the WTBC/USDC 86% LLTV market.',
+        title: 'Morpho WBTC/USDC 86% LLTV',
+        description: 'Only to be used for the WBTC/USDC 86% LLTV market.',
       },
       'morpho-cbbtc-usdc-860-lltv': {
         chains: ['ethereum'],


### PR DESCRIPTION
The aliases are created correctly, but I made a typo in the title and description, which affects the view on the API3 market.