### PR TITLE
Add rsETH/USDC and ezETH/USDC Morpho markets on Arbitrum

### DIFF
--- a/.changeset/many-aliens-brush.md
+++ b/.changeset/many-aliens-brush.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': minor
+---
+
+Add rsETH/USDC and ezETH/USDC Morpho markets on Arbitrum

--- a/data/dapps/morpho.json
+++ b/data/dapps/morpho.json
@@ -49,6 +49,16 @@
       "chains": ["gnosis"],
       "title": "Morpho sDAI/USDC 86% LLTV",
       "description": "Only to be used for the sDAI/USDC 86% LLTV market."
+    },
+    "morpho-rseth-usdc-770-lltv": {
+      "chains": ["arbitrum"],
+      "title": "Morpho rsETH/USDC 77% LLTV",
+      "description": "Only to be used for the rsETH/USDC 77% LLTV market."
+    },
+    "morpho-ezeth-usdc-770-lltv": {
+      "chains": ["arbitrum"],
+      "title": "Morpho ezETH/USDC 77% LLTV",
+      "description": "Only to be used for the ezETH/USDC 77% LLTV market."
     }
   },
   "homepageUrl": "https://morpho.org/vaults/"

--- a/src/generated/dapps.ts
+++ b/src/generated/dapps.ts
@@ -79,6 +79,16 @@ export const DAPPS: Dapp[] = [
         title: 'Morpho sDAI/USDC 86% LLTV',
         description: 'Only to be used for the sDAI/USDC 86% LLTV market.',
       },
+      'morpho-rseth-usdc-770-lltv': {
+        chains: ['arbitrum'],
+        title: 'Morpho rsETH/USDC 77% LLTV',
+        description: 'Only to be used for the rsETH/USDC 77% LLTV market.',
+      },
+      'morpho-ezeth-usdc-770-lltv': {
+        chains: ['arbitrum'],
+        title: 'Morpho ezETH/USDC 77% LLTV',
+        description: 'Only to be used for the ezETH/USDC 77% LLTV market.',
+      },
     },
     homepageUrl: 'https://morpho.org/vaults/',
   },


### PR DESCRIPTION
Both markets are to be created with 77% LLTV.

cc: @umersin61 