### PR TITLE
Add new RPC providers to somnia

### DIFF
--- a/.changeset/loud-cobras-feel.md
+++ b/.changeset/loud-cobras-feel.md
@@ -4,4 +4,4 @@
 
 Updates RPC provider configurations:
 
-- Add publicnode and 'stakely' providers for somnia chain.
+- Add publicnode and stakely providers for somnia chain.

--- a/.changeset/loud-cobras-feel.md
+++ b/.changeset/loud-cobras-feel.md
@@ -4,4 +4,4 @@
 
 Updates RPC provider configurations:
 
-- Add publicnode and stakely providers for somnia chain.
+- Add publicnode and validationcloud providers for somnia chain.

--- a/.changeset/loud-cobras-feel.md
+++ b/.changeset/loud-cobras-feel.md
@@ -1,0 +1,7 @@
+---
+'@api3/contracts': patch
+---
+
+Updates RPC provider configurations:
+
+- Add publicnode and 'stakely' providers for somnia chain.

--- a/data/chains/somnia.json
+++ b/data/chains/somnia.json
@@ -16,6 +16,14 @@
     {
       "alias": "default",
       "rpcUrl": "https://api.infra.mainnet.somnia.network/"
+    },
+    {
+      "alias": "publicnode",
+      "rpcUrl": "https://somnia-rpc.publicnode.com"
+    },
+    {
+      "alias": "stakely",
+      "rpcUrl": "https://somnia-json-rpc.stakely.io"
     }
   ],
   "symbol": "SOMI",

--- a/data/chains/somnia.json
+++ b/data/chains/somnia.json
@@ -22,8 +22,8 @@
       "rpcUrl": "https://somnia-rpc.publicnode.com"
     },
     {
-      "alias": "stakely",
-      "rpcUrl": "https://somnia-json-rpc.stakely.io"
+      "alias": "validationcloud",
+      "homepageUrl": "https://validationcloud.io/"
     }
   ],
   "symbol": "SOMI",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1180,7 +1180,11 @@ export const CHAINS: Chain[] = [
     },
     id: '5031',
     name: 'Somnia',
-    providers: [{ alias: 'default', rpcUrl: 'https://api.infra.mainnet.somnia.network/' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://api.infra.mainnet.somnia.network/' },
+      { alias: 'publicnode', rpcUrl: 'https://somnia-rpc.publicnode.com' },
+      { alias: 'stakely', rpcUrl: 'https://somnia-json-rpc.stakely.io' },
+    ],
     symbol: 'SOMI',
     testnet: false,
   },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1183,7 +1183,7 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://api.infra.mainnet.somnia.network/' },
       { alias: 'publicnode', rpcUrl: 'https://somnia-rpc.publicnode.com' },
-      { alias: 'stakely', rpcUrl: 'https://somnia-json-rpc.stakely.io' },
+      { alias: 'validationcloud', homepageUrl: 'https://validationcloud.io/' },
     ],
     symbol: 'SOMI',
     testnet: false,


### PR DESCRIPTION
Closes https://github.com/api3dao/contracts/issues/611

According to [docs](https://docs.somnia.network/developer/infrastructure-dev-tools/rpc#ankr) there are three RPC providers but [Ankr](https://www.ankr.com/rpc/somnia/) is still serving testnet only