### PR TITLE
Update verification API for scroll and scroll-sepolia-testnet

### DIFF
--- a/.changeset/violet-bananas-raise.md
+++ b/.changeset/violet-bananas-raise.md
@@ -1,0 +1,8 @@
+---
+'@api3/contracts': patch
+---
+
+Update verification API for following chains:
+
+- scroll
+- scroll-sepolia-testnet

--- a/data/chains/scroll-sepolia-testnet.json
+++ b/data/chains/scroll-sepolia-testnet.json
@@ -13,6 +13,7 @@
   "symbol": "ETH",
   "testnet": true,
   "verificationApi": {
-    "type": "etherscan"
+    "type": "blockscout",
+    "url": "https://sepolia.scrollscan.com/api"
   }
 }

--- a/data/chains/scroll.json
+++ b/data/chains/scroll.json
@@ -29,6 +29,7 @@
   "symbol": "ETH",
   "testnet": false,
   "verificationApi": {
-    "type": "etherscan"
+    "type": "blockscout",
+    "url": "https://scrollscan.com/api"
   }
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -637,7 +637,7 @@ export const CHAINS: Chain[] = [
     providers: [{ alias: 'default', rpcUrl: 'https://sepolia-rpc.scroll.io' }],
     symbol: 'ETH',
     testnet: true,
-    verificationApi: { type: 'etherscan' },
+    verificationApi: { type: 'blockscout', url: 'https://sepolia.scrollscan.com/api' },
   },
   {
     alias: 'scroll',
@@ -654,7 +654,7 @@ export const CHAINS: Chain[] = [
     ],
     symbol: 'ETH',
     testnet: false,
-    verificationApi: { type: 'etherscan' },
+    verificationApi: { type: 'blockscout', url: 'https://scrollscan.com/api' },
   },
   {
     alias: 'sei-testnet',


### PR DESCRIPTION
Closes [**Etherscan API support for Scroll ends**](https://github.com/api3dao/contracts/issues/758)

This PR updates verification API for scroll and scroll-sepolia-testnet to **blockscout** 

Block explorer remains the same while the provider has already migrated blockscout. 
Contracts have been verified.

See [docs](https://docs.scroll.io/en/developers)

CI complains can be ignored as deadline hasn't reached yet.

```bash
⚠️ scroll (ID: 534352) supports Etherscan v2 API but verificationApi is not set in the local chain list.
⚠️ scroll-sepolia-testnet (ID: 534351) supports Etherscan v2 API but verificationApi is not set in the local chain list.
```

