### PR TITLE
Update providers for sei

### DIFF
--- a/.changeset/nice-poets-create.md
+++ b/.changeset/nice-poets-create.md
@@ -1,0 +1,7 @@
+---
+'@api3/contracts': patch
+---
+
+Update RPC provider configurations:
+
+- Swap default and publicnode providers for sei

--- a/data/chains/sei.json
+++ b/data/chains/sei.json
@@ -7,11 +7,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://evm-rpc.sei-apis.com/"
+      "rpcUrl": "https://sei-evm-rpc.publicnode.com"
     },
     {
-      "alias": "publicnode",
-      "rpcUrl": "https://sei-evm-rpc.publicnode.com"
+      "alias": "public",
+      "rpcUrl": "https://evm-rpc.sei-apis.com/"
     },
     {
       "alias": "quicknode",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -677,8 +677,8 @@ export const CHAINS: Chain[] = [
     id: '1329',
     name: 'Sei',
     providers: [
-      { alias: 'default', rpcUrl: 'https://evm-rpc.sei-apis.com/' },
-      { alias: 'publicnode', rpcUrl: 'https://sei-evm-rpc.publicnode.com' },
+      { alias: 'default', rpcUrl: 'https://sei-evm-rpc.publicnode.com' },
+      { alias: 'public', rpcUrl: 'https://evm-rpc.sei-apis.com/' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'infura', homepageUrl: 'https://infura.io' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },


### PR DESCRIPTION
The current `default` provider for sei (`evm-rpc.sei-apis.com`) has been unreliable and intermittently down, so promote `sei-evm-rpc.publicnode.com` to `default` and keep the former default as a fallback.