### PR TITLE
Update providers for unichain-sepolia-testnet

### DIFF
--- a/.changeset/kind-webs-fix.md
+++ b/.changeset/kind-webs-fix.md
@@ -1,0 +1,7 @@
+---
+'@api3/contracts': patch
+---
+
+Update RPC provider configurations:
+
+- Swap default and publicnode providers for unichain-sepolia-testnet

--- a/data/chains/unichain-sepolia-testnet.json
+++ b/data/chains/unichain-sepolia-testnet.json
@@ -7,11 +7,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://sepolia.unichain.org"
+      "rpcUrl": "https://unichain-sepolia-rpc.publicnode.com"
     },
     {
-      "alias": "publicnode",
-      "rpcUrl": "https://unichain-sepolia-rpc.publicnode.com"
+      "alias": "public",
+      "rpcUrl": "https://sepolia.unichain.org"
     }
   ],
   "symbol": "ETH",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -789,8 +789,8 @@ export const CHAINS: Chain[] = [
     id: '1301',
     name: 'Unichain testnet',
     providers: [
-      { alias: 'default', rpcUrl: 'https://sepolia.unichain.org' },
-      { alias: 'publicnode', rpcUrl: 'https://unichain-sepolia-rpc.publicnode.com' },
+      { alias: 'default', rpcUrl: 'https://unichain-sepolia-rpc.publicnode.com' },
+      { alias: 'public', rpcUrl: 'https://sepolia.unichain.org' },
     ],
     symbol: 'ETH',
     testnet: true,


### PR DESCRIPTION
The current default provider (`https://sepolia.unichain.org`) occasionally causes discrepancies when sending transactions, submitted txes intermittently fail to get mined. The `publicnode` endpoint (`https://unichain-sepolia-rpc.publicnode.com`) has been more reliable in this respect, so promoting it to `default`.