### PR TITLE
Update providers

### DIFF
--- a/.changeset/smart-candles-smoke.md
+++ b/.changeset/smart-candles-smoke.md
@@ -1,0 +1,10 @@
+---
+'@api3/contracts': patch
+---
+
+Update RPC provider configurations:
+
+- Replace tenderly with publicnode for base
+- Add quicknode for katana
+- Update default RPC URL for kava
+- Add sentio for mode

--- a/.changeset/smart-candles-smoke.md
+++ b/.changeset/smart-candles-smoke.md
@@ -8,3 +8,4 @@ Update RPC provider configurations:
 - Add quicknode for katana
 - Update default RPC URL for kava
 - Add sentio for mode
+- Add drpc as default and keep previous default as public for ronin

--- a/data/chains/base.json
+++ b/data/chains/base.json
@@ -10,6 +10,10 @@
       "rpcUrl": "https://mainnet.base.org"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://base-rpc.publicnode.com"
+    },
+    {
       "alias": "quicknode",
       "homepageUrl": "https://quicknode.com"
     },
@@ -20,10 +24,6 @@
     {
       "alias": "blockpi",
       "homepageUrl": "https://blockpi.io"
-    },
-    {
-      "alias": "tenderly",
-      "homepageUrl": "https://tenderly.co/"
     }
   ],
   "symbol": "ETH",

--- a/data/chains/katana.json
+++ b/data/chains/katana.json
@@ -16,6 +16,10 @@
     {
       "alias": "tenderly",
       "homepageUrl": "https://tenderly.co/"
+    },
+    {
+      "alias": "quicknode",
+      "homepageUrl": "https://quicknode.com"
     }
   ],
   "symbol": "ETH",

--- a/data/chains/kava.json
+++ b/data/chains/kava.json
@@ -7,7 +7,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://evm.kava.io/"
+      "rpcUrl": "https://evm.kava-rpc.com/"
     },
     {
       "alias": "publicnode",

--- a/data/chains/mode.json
+++ b/data/chains/mode.json
@@ -10,6 +10,10 @@
       "rpcUrl": "https://mainnet.mode.network"
     },
     {
+      "alias": "sentio",
+      "rpcUrl": "https://mode-mainnet.rpc.sentio.xyz"
+    },
+    {
       "alias": "alchemy",
       "homepageUrl": "https://alchemy.com"
     }

--- a/data/chains/ronin.json
+++ b/data/chains/ronin.json
@@ -7,6 +7,10 @@
   "providers": [
     {
       "alias": "default",
+      "rpcUrl": "https://ronin.drpc.org"
+    },
+    {
+      "alias": "public",
       "rpcUrl": "https://api.roninchain.com/rpc/"
     },
     {

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -604,7 +604,8 @@ export const CHAINS: Chain[] = [
     id: '2020',
     name: 'Ronin',
     providers: [
-      { alias: 'default', rpcUrl: 'https://api.roninchain.com/rpc/' },
+      { alias: 'default', rpcUrl: 'https://ronin.drpc.org' },
+      { alias: 'public', rpcUrl: 'https://api.roninchain.com/rpc/' },
       { alias: 'alchemy', homepageUrl: 'https://alchemy.com' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
       { alias: 'dwellir', homepageUrl: 'https://dwellir.com' },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -119,10 +119,10 @@ export const CHAINS: Chain[] = [
     name: 'Base',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.base.org' },
+      { alias: 'publicnode', rpcUrl: 'https://base-rpc.publicnode.com' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
       { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
-      { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
     ],
     symbol: 'ETH',
     testnet: false,
@@ -366,6 +366,7 @@ export const CHAINS: Chain[] = [
       { alias: 'default', rpcUrl: 'https://rpc.katana.network' },
       { alias: 'conduit', homepageUrl: 'https://conduit.xyz' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
+      { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
     ],
     symbol: 'ETH',
     testnet: false,
@@ -389,7 +390,7 @@ export const CHAINS: Chain[] = [
     id: '2222',
     name: 'Kava',
     providers: [
-      { alias: 'default', rpcUrl: 'https://evm.kava.io/' },
+      { alias: 'default', rpcUrl: 'https://evm.kava-rpc.com/' },
       { alias: 'publicnode', rpcUrl: 'https://kava-evm-rpc.publicnode.com/' },
     ],
     symbol: 'KAVA',
@@ -486,6 +487,7 @@ export const CHAINS: Chain[] = [
     name: 'Mode',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.mode.network' },
+      { alias: 'sentio', rpcUrl: 'https://mode-mainnet.rpc.sentio.xyz' },
       { alias: 'alchemy', homepageUrl: 'https://alchemy.com' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
This PR updates RPC providers for several networks to improve reliability and performance.

## Changes

- **base**: Replaced `tenderly` with `publicnode` (`https://base-rpc.publicnode.com`)
- **katana**: Added `quicknode` as an additional provider
- **kava**: Updated `default` RPC URL from `https://evm.kava.io/` to `https://evm.kava-rpc.com/`
- **mode**: Added `sentio` provider (`https://mode-mainnet.rpc.sentio.xyz`)
- **ronin**: Added `drpc` (`https://ronin.drpc.org`) as the new `default` provider because `eth_getTransactionByHash` stopped working on the previous default (likely no longer backed by an archive node). Original public provider is kept as a fallback under the `public` alias.
