### PR TITLE
Update providers

### DIFF
--- a/.changeset/spicy-donuts-jump.md
+++ b/.changeset/spicy-donuts-jump.md
@@ -1,0 +1,11 @@
+---
+'@api3/contracts': patch
+---
+
+Update RPC provider configurations:
+
+- Make publicnode default and keep previous default as public for base
+- Remove icecreamswap from core
+- Remove conduit from katana
+- Remove unitedbloc from moonbeam
+- Remove unresponsive default provider and promote public to default for sei-testnet

--- a/data/chains/base.json
+++ b/data/chains/base.json
@@ -7,11 +7,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://mainnet.base.org"
+      "rpcUrl": "https://base-rpc.publicnode.com"
     },
     {
-      "alias": "publicnode",
-      "rpcUrl": "https://base-rpc.publicnode.com"
+      "alias": "public",
+      "rpcUrl": "https://mainnet.base.org"
     },
     {
       "alias": "quicknode",

--- a/data/chains/core.json
+++ b/data/chains/core.json
@@ -12,10 +12,6 @@
     {
       "alias": "public",
       "rpcUrl": "https://rpcar.coredao.org/"
-    },
-    {
-      "alias": "icecreamswap",
-      "rpcUrl": "https://rpc-core.icecreamswap.com/"
     }
   ],
   "symbol": "CORE",

--- a/data/chains/katana.json
+++ b/data/chains/katana.json
@@ -10,10 +10,6 @@
       "rpcUrl": "https://rpc.katana.network"
     },
     {
-      "alias": "conduit",
-      "homepageUrl": "https://conduit.xyz"
-    },
-    {
       "alias": "tenderly",
       "homepageUrl": "https://tenderly.co/"
     },

--- a/data/chains/moonbeam.json
+++ b/data/chains/moonbeam.json
@@ -14,10 +14,6 @@
       "rpcUrl": "https://rpc.api.moonbeam.network"
     },
     {
-      "alias": "unitedbloc",
-      "rpcUrl": "https://moonbeam.unitedbloc.com"
-    },
-    {
       "alias": "reblok",
       "homepageUrl": "https://reblok.io"
     }

--- a/data/chains/sei-testnet.json
+++ b/data/chains/sei-testnet.json
@@ -7,10 +7,6 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://sei-testnet-public.nodies.app"
-    },
-    {
-      "alias": "public",
       "rpcUrl": "https://evm-rpc-testnet.sei-apis.com"
     }
   ],

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -118,8 +118,8 @@ export const CHAINS: Chain[] = [
     id: '8453',
     name: 'Base',
     providers: [
-      { alias: 'default', rpcUrl: 'https://mainnet.base.org' },
-      { alias: 'publicnode', rpcUrl: 'https://base-rpc.publicnode.com' },
+      { alias: 'default', rpcUrl: 'https://base-rpc.publicnode.com' },
+      { alias: 'public', rpcUrl: 'https://mainnet.base.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
       { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
@@ -203,7 +203,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.coredao.org/' },
       { alias: 'public', rpcUrl: 'https://rpcar.coredao.org/' },
-      { alias: 'icecreamswap', rpcUrl: 'https://rpc-core.icecreamswap.com/' },
     ],
     symbol: 'CORE',
     testnet: false,
@@ -364,7 +363,6 @@ export const CHAINS: Chain[] = [
     name: 'Katana',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.katana.network' },
-      { alias: 'conduit', homepageUrl: 'https://conduit.xyz' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
     ],
@@ -517,7 +515,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://moonbeam-rpc.publicnode.com' },
       { alias: 'public', rpcUrl: 'https://rpc.api.moonbeam.network' },
-      { alias: 'unitedbloc', rpcUrl: 'https://moonbeam.unitedbloc.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
     ],
     symbol: 'GLMR',
@@ -648,10 +645,7 @@ export const CHAINS: Chain[] = [
     decimals: 18,
     id: '1328',
     name: 'Sei testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://sei-testnet-public.nodies.app' },
-      { alias: 'public', rpcUrl: 'https://evm-rpc-testnet.sei-apis.com' },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://evm-rpc-testnet.sei-apis.com' }],
     symbol: 'SEI',
     testnet: true,
     verificationApi: { type: 'etherscan' },


### PR DESCRIPTION
This PR updates RPC providers for several networks to improve reliability and performance.

## Changes

- **base**: Made `publicnode` (`https://base-rpc.publicnode.com`) the new `default` provider. The previous default (`https://mainnet.base.org`) is kept as a fallback under the `public` alias.
- **core**: Removed `icecreamswap` because it started to not respond.
- **katana**: Removed `conduit` because it returns a gas price significantly higher than usual (around 10000x).
- **moonbeam**: Removed `unitedbloc` because it mostly fails to respond to requests and fails to sync with the head of the chain.
- **sei-testnet**: Removed the previous `default` provider (`https://sei-testnet-public.nodies.app`) because it started to not respond, and promoted the `public` provider (`https://evm-rpc-testnet.sei-apis.com`) to `default`.
