### PR TITLE
Update providers

### DIFF
--- a/.changeset/brave-otters-drum.md
+++ b/.changeset/brave-otters-drum.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': patch
+---
+
+Update default provider for moonbeam-testnet and polygon-sepolia-testnet

--- a/data/chains/moonbeam-testnet.json
+++ b/data/chains/moonbeam-testnet.json
@@ -7,10 +7,6 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://moonbase.unitedbloc.com"
-    },
-    {
-      "alias": "public",
       "rpcUrl": "https://rpc.api.moonbase.moonbeam.network"
     }
   ],

--- a/data/chains/polygon-sepolia-testnet.json
+++ b/data/chains/polygon-sepolia-testnet.json
@@ -7,7 +7,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc-amoy.polygon.technology"
+      "rpcUrl": "https://polygon-amoy-bor-rpc.publicnode.com"
     },
     {
       "alias": "tenderly-public",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -498,10 +498,7 @@ export const CHAINS: Chain[] = [
     decimals: 18,
     id: '1287',
     name: 'Moonbeam testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://moonbase.unitedbloc.com' },
-      { alias: 'public', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' }],
     symbol: 'GLMR',
     testnet: true,
     verificationApi: { type: 'etherscan' },
@@ -559,7 +556,7 @@ export const CHAINS: Chain[] = [
     id: '80002',
     name: 'Polygon testnet',
     providers: [
-      { alias: 'default', rpcUrl: 'https://rpc-amoy.polygon.technology' },
+      { alias: 'default', rpcUrl: 'https://polygon-amoy-bor-rpc.publicnode.com' },
       { alias: 'tenderly-public', rpcUrl: 'https://polygon-amoy.gateway.tenderly.co' },
     ],
     symbol: 'POL',


### PR DESCRIPTION
This PR replaces the unresponsive default providers for two testnets.

## Changes

- **moonbeam-testnet**: Removed the previous `default` provider (`https://moonbase.unitedbloc.com`) because its SSL certificate does not match the hostname, and promoted the `public` provider (`https://rpc.api.moonbase.moonbeam.network`) to `default`.
- **polygon-sepolia-testnet**: Replaced the previous `default` provider (`https://rpc-amoy.polygon.technology`) because its hostname no longer resolves, making `https://polygon-amoy-bor-rpc.publicnode.com` the new `default`. The `tenderly-public` provider is kept as is.
