### PR TITLE
Add Base chain to morpho-api3 alias

### DIFF
--- a/.changeset/fresh-lies-sort.md
+++ b/.changeset/fresh-lies-sort.md
@@ -1,0 +1,5 @@
+---
+'@api3/contracts': minor
+---
+
+Add Base support to morpho-api3 dApp alias data

--- a/data/dapps/morpho.json
+++ b/data/dapps/morpho.json
@@ -71,7 +71,7 @@
       "description": "Only to be used for the Morpho market(s) by Feather."
     },
     "morpho-api3": {
-      "chains": ["ethereum", "robinhood"],
+      "chains": ["ethereum", "robinhood", "base"],
       "title": "Morpho market(s) by Api3",
       "description": "Only to be used for the Morpho market(s) by Api3."
     }

--- a/src/generated/dapps.ts
+++ b/src/generated/dapps.ts
@@ -124,7 +124,7 @@ export const DAPPS: Dapp[] = [
         description: 'Only to be used for the Morpho market(s) by Feather.',
       },
       'morpho-api3': {
-        chains: ['ethereum', 'robinhood'],
+        chains: ['ethereum', 'robinhood', 'base'],
         title: 'Morpho market(s) by Api3',
         description: 'Only to be used for the Morpho market(s) by Api3.',
       },


### PR DESCRIPTION
Related https://github.com/api3dao/morpho-curation/issues/48

To be used for new Kabu vault markets on Base.