### PR TITLE
Update providers

### DIFF
--- a/.changeset/rare-falcons-tap.md
+++ b/.changeset/rare-falcons-tap.md
@@ -1,0 +1,8 @@
+---
+'@api3/contracts': patch
+---
+
+Update RPC provider configurations:
+
+- Replace default with tenderly for ronin
+- Remove drpc from zircuit

--- a/data/chains/ronin.json
+++ b/data/chains/ronin.json
@@ -7,7 +7,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://ronin.drpc.org"
+      "rpcUrl": "https://ronin.gateway.tenderly.co"
     },
     {
       "alias": "public",

--- a/data/chains/zircuit.json
+++ b/data/chains/zircuit.json
@@ -12,10 +12,6 @@
     {
       "alias": "sentio",
       "rpcUrl": "https://rpc.sentio.xyz/zircuit"
-    },
-    {
-      "alias": "drpc",
-      "homepageUrl": "https://drpc.org"
     }
   ],
   "symbol": "ETH",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -634,7 +634,7 @@ export const CHAINS: Chain[] = [
     id: '2020',
     name: 'Ronin',
     providers: [
-      { alias: 'default', rpcUrl: 'https://ronin.drpc.org' },
+      { alias: 'default', rpcUrl: 'https://ronin.gateway.tenderly.co' },
       { alias: 'public', rpcUrl: 'https://api.roninchain.com/rpc/' },
       { alias: 'alchemy', homepageUrl: 'https://alchemy.com' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
@@ -890,7 +890,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.zircuit.com' },
       { alias: 'sentio', rpcUrl: 'https://rpc.sentio.xyz/zircuit' },
-      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',
     testnet: false,


### PR DESCRIPTION
This PR updates RPC providers for the networks below.

**Changes:**

- **ronin**: Replaced the `default` provider (`https://ronin.drpc.org`) with `tenderly` (`https://ronin.gateway.tenderly.co`) because the previous one fails to estimate gas. The `public` provider (`https://api.roninchain.com/rpc/`) is kept as is rather than promoted to `default`, because it is not an archive node and CI fails against it while fetching the contract creation transaction.
- **zircuit**: Removed `drpc` because it started to not respond to requests.